### PR TITLE
feat(profile-review): Rank Gate UI + 레이아웃 개선

### DIFF
--- a/app/admin/profile-review/components/ImageReviewPanel.tsx
+++ b/app/admin/profile-review/components/ImageReviewPanel.tsx
@@ -10,10 +10,6 @@ import {
   Divider,
   TextField,
   Link,
-  Select,
-  MenuItem,
-  FormControl,
-  InputLabel,
   Tooltip,
 } from "@mui/material";
 import { PendingUser } from "../page";
@@ -110,24 +106,14 @@ export default function ImageReviewPanel({
   const handleRankChange = async (newRank: string) => {
     if (!user || newRank === currentRank) return;
 
-    const confirmed = window.confirm(
-      `정말로 이 유저의 Rank를 ${newRank}(으)로 변경하시겠습니까?`,
-    );
-
-    if (!confirmed) return;
-
     const previousRank = currentRank;
     setCurrentRank(newRank);
     setIsUpdatingRank(true);
 
     try {
-      const result = await AdminService.userReview.updateUserRank(
+      await AdminService.userReview.updateUserRank(
         user.userId,
         newRank as any,
-      );
-
-      alert(
-        `Rank가 ${result.previousRank}에서 ${result.updatedRank}(으)로 변경되었습니다.`,
       );
     } catch (error: any) {
       console.error("Rank 업데이트 실패:", error);
@@ -507,55 +493,6 @@ export default function ImageReviewPanel({
           </Box>
         </Box>
       )}
-
-      <Divider sx={{ mb: 2 }} />
-
-      {/* Rank 관리 */}
-      <Box sx={{ mb: 3 }}>
-        <Typography variant="subtitle2" sx={{ mb: 2, fontWeight: 600 }}>
-          유저 Rank 관리
-        </Typography>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
-          <Box>
-            <Typography
-              variant="caption"
-              color="text.secondary"
-              sx={{ display: "block", mb: 0.5 }}
-            >
-              현재 Rank
-            </Typography>
-            <Tooltip title={getRankConfig(currentRank).tooltip}>
-              <Chip
-                label={getRankConfig(currentRank).label}
-                sx={{
-                  backgroundColor: getRankConfig(currentRank).bgColor,
-                  color: getRankConfig(currentRank).color,
-                  fontWeight: "bold",
-                  minWidth: 80,
-                  fontSize: "0.9rem",
-                }}
-              />
-            </Tooltip>
-          </Box>
-          <Box sx={{ flex: 1 }}>
-            <FormControl fullWidth size="small">
-              <InputLabel>Rank 변경</InputLabel>
-              <Select
-                value={currentRank}
-                label="Rank 변경"
-                onChange={(e) => handleRankChange(e.target.value)}
-                disabled={isUpdatingRank}
-              >
-                <MenuItem value="S">S등급 (최상위)</MenuItem>
-                <MenuItem value="A">A등급 (상위)</MenuItem>
-                <MenuItem value="B">B등급 (중위)</MenuItem>
-                <MenuItem value="C">C등급 (하위)</MenuItem>
-                <MenuItem value="UNKNOWN">미분류</MenuItem>
-              </Select>
-            </FormControl>
-          </Box>
-        </Box>
-      </Box>
 
       <Divider sx={{ mb: 2 }} />
 
@@ -975,6 +912,53 @@ export default function ImageReviewPanel({
         </Box>
       </Box>
 
+      {/* Rank 선택 (필수) */}
+      <Box sx={{ mb: 3, mt: 2 }}>
+        <Typography variant="subtitle2" sx={{ mb: 1.5, fontWeight: 600 }}>
+          Rank 선택
+        </Typography>
+        {currentRank === "UNKNOWN" && (
+          <Typography
+            variant="caption"
+            sx={{ color: "#ed6c02", display: "block", mb: 1 }}
+          >
+            승인하려면 Rank를 먼저 선택해주세요
+          </Typography>
+        )}
+        <Box sx={{ display: "flex", gap: 1 }}>
+          {(["S", "A", "B", "C"] as const).map((rank) => {
+            const config = getRankConfig(rank);
+            const isSelected = currentRank === rank;
+            return (
+              <Chip
+                key={rank}
+                label={`${rank}등급`}
+                onClick={() => handleRankChange(rank)}
+                disabled={isUpdatingRank}
+                sx={{
+                  flex: 1,
+                  height: 40,
+                  fontSize: "0.9rem",
+                  fontWeight: "bold",
+                  cursor: "pointer",
+                  backgroundColor: isSelected ? config.color : config.bgColor,
+                  color: isSelected ? "#fff" : config.color,
+                  border: isSelected
+                    ? `2px solid ${config.color}`
+                    : "2px solid transparent",
+                  "&:hover": {
+                    backgroundColor: isSelected
+                      ? config.color
+                      : config.bgColor,
+                    opacity: 0.85,
+                  },
+                }}
+              />
+            );
+          })}
+        </Box>
+      </Box>
+
       {/* 승인/거절 버튼 */}
       <Box sx={{ display: "flex", gap: 1.5 }}>
         <Button
@@ -988,12 +972,27 @@ export default function ImageReviewPanel({
         </Button>
         <Button
           variant="contained"
-          color="primary"
           fullWidth
+          disabled={currentRank === "UNKNOWN" || processing}
           onClick={handleApprove}
-          sx={{ height: 48 }}
+          sx={{
+            height: 48,
+            backgroundColor:
+              currentRank !== "UNKNOWN"
+                ? getRankConfig(currentRank).color
+                : undefined,
+            "&:hover": {
+              backgroundColor:
+                currentRank !== "UNKNOWN"
+                  ? getRankConfig(currentRank).color
+                  : undefined,
+              opacity: 0.9,
+            },
+          }}
         >
-          승인하기
+          {currentRank !== "UNKNOWN"
+            ? `${currentRank}등급으로 승인하기`
+            : "승인하기"}
         </Button>
       </Box>
 

--- a/app/admin/profile-review/page.tsx
+++ b/app/admin/profile-review/page.tsx
@@ -851,8 +851,16 @@ export default function ProfileReviewPage() {
         </Alert>
       )}
 
-      <Box sx={{ display: "flex", gap: 3, height: "calc(100vh - 200px)" }}>
-        <Box sx={{ flex: "7", overflow: "auto" }}>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+          height: "calc(100vh - 200px)",
+        }}
+      >
+        {/* 상단: 유저 테이블 */}
+        <Box sx={{ flex: "4", overflow: "auto", minHeight: 0 }}>
           <UserTableList
             users={users}
             selectedUser={selectedUser}
@@ -867,7 +875,8 @@ export default function ProfileReviewPage() {
           />
         </Box>
 
-        <Box sx={{ flex: "3", overflow: "auto" }}>
+        {/* 하단: 심사 패널 (전체 너비) */}
+        <Box sx={{ flex: "6", overflow: "auto", minHeight: 0 }}>
           <ImageReviewPanel
             user={selectedUser}
             onApprove={handleApproveUser}


### PR DESCRIPTION
## Summary
- Rank 미선택(UNKNOWN) 상태에서 승인 버튼 비활성화 → 미분류 유저 발생 휴먼 에러 방지
- Rank 선택 UI를 드롭다운에서 Chip 버튼(S/A/B/C)으로 변경 → 직관적 시각 피드백
- 레이아웃을 좌우 분할(7:3)에서 상하 분할(4:6)로 변경 → 이미지 한눈에 확인 가능

## 변경 파일
- `ImageReviewPanel.tsx` — Rank Chip UI + 승인 버튼 Gate 로직
- `page.tsx` — 상단 테이블 + 하단 심사 패널 레이아웃

## Test plan
- [ ] `/admin/profile-review` 접속 후 유저 선택
- [ ] Rank 미선택 시 승인 버튼 disabled 확인
- [ ] Chip 클릭으로 Rank 선택 → 버튼 활성화 + 랭크 컬러 적용 확인
- [ ] 상단 테이블 + 하단 심사 패널 레이아웃 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)