### PR TITLE
feat(profile-review): C안 레이아웃 — 좌우 30:70 + 3열 이미지 그리드

### DIFF
--- a/app/admin/profile-review/components/ImageReviewPanel.tsx
+++ b/app/admin/profile-review/components/ImageReviewPanel.tsx
@@ -7,6 +7,7 @@ import {
   IconButton,
   Dialog,
   Chip,
+  Collapse,
   Divider,
   TextField,
   Link,
@@ -26,6 +27,8 @@ import SchoolIcon from "@mui/icons-material/School";
 import NewReleasesIcon from "@mui/icons-material/NewReleases";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import AdminService from "@/app/services/admin";
 import {
   mapImagesBySlot,
@@ -98,6 +101,7 @@ export default function ImageReviewPanel({
     user?.rank || "UNKNOWN",
   );
   const [isUpdatingRank, setIsUpdatingRank] = useState(false);
+  const [showReviewContext, setShowReviewContext] = useState(false);
 
   useEffect(() => {
     setCurrentRank(user?.rank || "UNKNOWN");
@@ -310,7 +314,35 @@ export default function ImageReviewPanel({
         )}
       </Box>
 
-      <Divider sx={{ mb: 2 }} />
+      <Box
+        onClick={() => setShowReviewContext(!showReviewContext)}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          cursor: "pointer",
+          py: 1,
+          px: 0.5,
+          borderTop: "1px solid #e0e0e0",
+          borderBottom: "1px solid #e0e0e0",
+          mb: 1,
+          "&:hover": { backgroundColor: "#f5f5f5" },
+        }}
+      >
+        <Typography variant="caption" sx={{ fontWeight: 600, color: "#667085" }}>
+          📋 심사 상세 정보 (선호도, 거절 이력, 참고 정보)
+        </Typography>
+        <ExpandMoreIcon
+          sx={{
+            fontSize: 20,
+            color: "#667085",
+            transform: showReviewContext ? "rotate(180deg)" : "rotate(0deg)",
+            transition: "transform 0.2s",
+          }}
+        />
+      </Box>
+
+      <Collapse in={showReviewContext}>
 
       {/* 심사 참고 정보 */}
       {user.reviewContext && (
@@ -649,6 +681,8 @@ export default function ImageReviewPanel({
         </Box>
       )}
 
+      </Collapse>
+
       {/* 프로필 이미지 - Before/After 비교 */}
       <Box sx={{ mb: 3 }}>
         <Typography variant="subtitle2" sx={{ mb: 2, fontWeight: 600 }}>
@@ -657,7 +691,7 @@ export default function ImageReviewPanel({
           중)
         </Typography>
 
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+        <Box sx={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 1.5 }}>
           {Array.from(
             mapImagesBySlot(
               user.profileUsing,
@@ -669,16 +703,16 @@ export default function ImageReviewPanel({
               <Box
                 key={slotIndex}
                 sx={{
-                  p: 2,
+                  p: 1.5,
                   backgroundColor: "#fafafa",
                   borderRadius: 2,
                   border: "1px solid #e0e0e0",
                 }}
               >
                 <Box
-                  sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}
+                  sx={{ display: "flex", alignItems: "center", gap: 0.5, mb: 1 }}
                 >
-                  <Typography variant="body2" fontWeight="bold">
+                  <Typography variant="caption" fontWeight="bold" sx={{ fontSize: "0.75rem" }}>
                     {getSlotLabel(slotIndex)}
                   </Typography>
                   {slotIndex === 0 && (
@@ -689,224 +723,173 @@ export default function ImageReviewPanel({
                         backgroundColor: "#ff9800",
                         color: "white",
                         fontWeight: 700,
-                        fontSize: "0.7rem",
+                        fontSize: "0.65rem",
+                        height: 20,
                       }}
                     />
                   )}
                 </Box>
 
-                <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
-                  {/* 현재 사용 중인 이미지 */}
-                  <Box sx={{ flex: 1 }}>
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      sx={{ display: "block", mb: 1 }}
-                    >
-                      현재 사용 중
-                    </Typography>
-                    {pair.current ? (
-                      <Box
-                        sx={{
-                          position: "relative",
-                          borderRadius: 2,
-                          overflow: "hidden",
-                          cursor: "pointer",
-                          border: "2px solid #4caf50",
-                          "&:hover": {
-                            transform: "scale(1.02)",
-                            transition: "transform 0.2s",
-                          },
-                        }}
-                        onClick={() => handleImageClick(pair.current!.imageUrl)}
-                      >
-                        <Box sx={{ position: "relative", paddingTop: "100%" }}>
-                          <Box
-                            component="img"
-                            src={pair.current.imageUrl}
-                            alt="현재 프로필"
-                            sx={{
-                              position: "absolute",
-                              top: 0,
-                              left: 0,
-                              width: "100%",
-                              height: "100%",
-                              objectFit: "cover",
-                            }}
-                          />
-                        </Box>
-                        <Box
-                          sx={{
-                            p: 1,
-                            backgroundColor: "#e8f5e9",
-                            display: "flex",
-                            justifyContent: "space-between",
-                            alignItems: "center",
-                          }}
-                        >
-                          <Typography
-                            variant="caption"
-                            sx={{ fontSize: "0.65rem", color: "#2e7d32" }}
-                          >
-                            승인일:{" "}
-                            {formatApprovedDate(pair.current.approvedAt)}
-                          </Typography>
-                        </Box>
-                      </Box>
-                    ) : (
-                      <Box
-                        sx={{
-                          position: "relative",
-                          paddingTop: "100%",
-                          backgroundColor: "#f5f5f5",
-                          borderRadius: 2,
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                        }}
-                      >
-                        <Typography
-                          variant="caption"
-                          color="text.secondary"
-                          sx={{
-                            position: "absolute",
-                            top: "50%",
-                            left: "50%",
-                            transform: "translate(-50%, -50%)",
-                          }}
-                        >
-                          없음
-                        </Typography>
-                      </Box>
-                    )}
-                  </Box>
-
-                  {/* 화살표 */}
+                {/* 이전 사진 (위) */}
+                <Typography
+                  variant="caption"
+                  sx={{ display: "block", mb: 0.5, color: "#4caf50", fontWeight: 600, fontSize: "0.7rem" }}
+                >
+                  ● 이전
+                </Typography>
+                {pair.current ? (
                   <Box
                     sx={{
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      px: 1,
+                      position: "relative",
+                      borderRadius: 1.5,
+                      overflow: "hidden",
+                      cursor: "pointer",
+                      border: "2px solid #4caf50",
+                      "&:hover": { opacity: 0.9 },
+                    }}
+                    onClick={() => handleImageClick(pair.current!.imageUrl)}
+                  >
+                    <Box sx={{ position: "relative", paddingTop: "100%" }}>
+                      <Box
+                        component="img"
+                        src={pair.current.imageUrl}
+                        alt="현재 프로필"
+                        sx={{
+                          position: "absolute",
+                          top: 0,
+                          left: 0,
+                          width: "100%",
+                          height: "100%",
+                          objectFit: "cover",
+                        }}
+                      />
+                    </Box>
+                  </Box>
+                ) : (
+                  <Box
+                    sx={{
+                      position: "relative",
+                      paddingTop: "100%",
+                      backgroundColor: "#f5f5f5",
+                      borderRadius: 1.5,
+                      border: "2px dashed #d0d5dd",
                     }}
                   >
-                    <ArrowForwardIcon sx={{ fontSize: 32, color: "#9e9e9e" }} />
-                  </Box>
-
-                  {/* 심사 대기 이미지 */}
-                  <Box sx={{ flex: 1 }}>
                     <Typography
                       variant="caption"
                       color="text.secondary"
-                      sx={{ display: "block", mb: 1 }}
+                      sx={{
+                        position: "absolute",
+                        top: "50%",
+                        left: "50%",
+                        transform: "translate(-50%, -50%)",
+                        fontSize: "0.7rem",
+                      }}
                     >
-                      변경 예정
+                      없음
                     </Typography>
-                    {pair.pending ? (
-                      <Box sx={{ position: "relative" }}>
+                  </Box>
+                )}
+
+                {/* 화살표 */}
+                <Box sx={{ textAlign: "center", py: 0.25 }}>
+                  <ArrowDownwardIcon sx={{ fontSize: 18, color: "#d0d5dd" }} />
+                </Box>
+
+                {/* 변경 예정 (아래) */}
+                <Typography
+                  variant="caption"
+                  sx={{ display: "block", mb: 0.5, color: "#ff9800", fontWeight: 600, fontSize: "0.7rem" }}
+                >
+                  ● 변경
+                </Typography>
+                {pair.pending ? (
+                  <Box sx={{ position: "relative" }}>
+                    <Box
+                      sx={{
+                        position: "relative",
+                        borderRadius: 1.5,
+                        overflow: "hidden",
+                        cursor: "pointer",
+                        border: "2px solid #ff9800",
+                        "&:hover": { opacity: 0.9 },
+                      }}
+                      onClick={() =>
+                        handleImageClick(pair.pending!.imageUrl)
+                      }
+                    >
+                      <Box sx={{ position: "relative", paddingTop: "100%" }}>
                         <Box
-                          sx={{
-                            position: "relative",
-                            borderRadius: 2,
-                            overflow: "hidden",
-                            cursor: "pointer",
-                            border: "2px solid #ff9800",
-                            "&:hover": {
-                              transform: "scale(1.02)",
-                              transition: "transform 0.2s",
-                            },
-                          }}
-                          onClick={() =>
-                            handleImageClick(pair.pending!.imageUrl)
-                          }
-                        >
-                          <Box
-                            sx={{ position: "relative", paddingTop: "100%" }}
-                          >
-                            <Box
-                              component="img"
-                              src={pair.pending.imageUrl}
-                              alt="대기 중인 프로필"
-                              sx={{
-                                position: "absolute",
-                                top: 0,
-                                left: 0,
-                                width: "100%",
-                                height: "100%",
-                                objectFit: "cover",
-                              }}
-                            />
-                          </Box>
-                        </Box>
-                        <Box
-                          sx={{
-                            display: "flex",
-                            flexDirection: "column",
-                            gap: 1,
-                            mt: 1,
-                            alignItems: "center",
-                          }}
-                        >
-                          <Box sx={{ display: "flex", gap: 1 }}>
-                            <IconButton
-                              size="small"
-                              onClick={() =>
-                                handleRejectImageClick(pair.pending!.id)
-                              }
-                              sx={{
-                                backgroundColor: "#f44336",
-                                color: "#fff",
-                                width: 36,
-                                height: 36,
-                                "&:hover": { backgroundColor: "#d32f2f" },
-                              }}
-                            >
-                              <CloseIcon fontSize="small" />
-                            </IconButton>
-                            <IconButton
-                              size="small"
-                              onClick={() => handleApproveImage(pair.pending!.id)}
-                              sx={{
-                                backgroundColor: "#4caf50",
-                                color: "#fff",
-                                width: 36,
-                                height: 36,
-                                "&:hover": { backgroundColor: "#388e3c" },
-                              }}
-                            >
-                              <CheckCircleIcon fontSize="small" />
-                            </IconButton>
-                          </Box>
-                        </Box>
-                      </Box>
-                    ) : (
-                      <Box
-                        sx={{
-                          position: "relative",
-                          paddingTop: "100%",
-                          backgroundColor: "#f5f5f5",
-                          borderRadius: 2,
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                        }}
-                      >
-                        <Typography
-                          variant="caption"
-                          color="text.secondary"
+                          component="img"
+                          src={pair.pending.imageUrl}
+                          alt="대기 중인 프로필"
                           sx={{
                             position: "absolute",
-                            top: "50%",
-                            left: "50%",
-                            transform: "translate(-50%, -50%)",
+                            top: 0,
+                            left: 0,
+                            width: "100%",
+                            height: "100%",
+                            objectFit: "cover",
                           }}
-                        >
-                          없음
-                        </Typography>
+                        />
                       </Box>
-                    )}
+                    </Box>
+                    <Box sx={{ display: "flex", gap: 0.5, mt: 0.75, justifyContent: "center" }}>
+                      <IconButton
+                        size="small"
+                        onClick={() =>
+                          handleRejectImageClick(pair.pending!.id)
+                        }
+                        sx={{
+                          backgroundColor: "#f44336",
+                          color: "#fff",
+                          width: 28,
+                          height: 28,
+                          "&:hover": { backgroundColor: "#d32f2f" },
+                        }}
+                      >
+                        <CloseIcon sx={{ fontSize: 16 }} />
+                      </IconButton>
+                      <IconButton
+                        size="small"
+                        onClick={() => handleApproveImage(pair.pending!.id)}
+                        sx={{
+                          backgroundColor: "#4caf50",
+                          color: "#fff",
+                          width: 28,
+                          height: 28,
+                          "&:hover": { backgroundColor: "#388e3c" },
+                        }}
+                      >
+                        <CheckCircleIcon sx={{ fontSize: 16 }} />
+                      </IconButton>
+                    </Box>
                   </Box>
-                </Box>
+                ) : (
+                  <Box
+                    sx={{
+                      position: "relative",
+                      paddingTop: "100%",
+                      backgroundColor: "#f5f5f5",
+                      borderRadius: 1.5,
+                      border: "2px dashed #d0d5dd",
+                    }}
+                  >
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{
+                        position: "absolute",
+                        top: "50%",
+                        left: "50%",
+                        transform: "translate(-50%, -50%)",
+                        fontSize: "0.7rem",
+                      }}
+                    >
+                      없음
+                    </Typography>
+                  </Box>
+                )}
               </Box>
             ))}
         </Box>

--- a/app/admin/profile-review/components/UserTableList.tsx
+++ b/app/admin/profile-review/components/UserTableList.tsx
@@ -34,6 +34,7 @@ interface UserTableListProps {
   selectedUserIds?: string[];
   onUserCheck?: (userId: string, checked: boolean) => void;
   onSelectAllCheck?: (checked: boolean) => void;
+  compact?: boolean;
 }
 
 const getRankConfig = (rank?: string) => {
@@ -103,6 +104,7 @@ export default function UserTableList({
   selectedUserIds = [],
   onUserCheck,
   onSelectAllCheck,
+  compact = false,
 }: UserTableListProps) {
   const isAllSelected = users.length > 0 && users.every(user => selectedUserIds.includes(user.userId));
   const isSomeSelected = selectedUserIds.length > 0 && !isAllSelected;
@@ -139,14 +141,14 @@ export default function UserTableList({
                 </TableCell>
               )}
               <TableCell>이름</TableCell>
-              <TableCell>나이/성별</TableCell>
+              {!compact && <TableCell>나이/성별</TableCell>}
               <TableCell align="center">Rank</TableCell>
-              <TableCell>대학교</TableCell>
-              <TableCell>학과</TableCell>
+              {!compact && <TableCell>대학교</TableCell>}
+              {!compact && <TableCell>학과</TableCell>}
               <TableCell align="center">사진 수</TableCell>
-              <TableCell>MBTI</TableCell>
-              <TableCell align="center">최초심사</TableCell>
-              <TableCell>등록일시</TableCell>
+              {!compact && <TableCell>MBTI</TableCell>}
+              {!compact && <TableCell align="center">최초심사</TableCell>}
+              {!compact && <TableCell>등록일시</TableCell>}
               {onSkipUser && <TableCell align="center" sx={{ width: 50 }}></TableCell>}
             </TableRow>
           </TableHead>
@@ -180,7 +182,13 @@ export default function UserTableList({
                   <Typography variant="body2" fontWeight="medium">
                     {user.name}
                   </Typography>
+                  {compact && (
+                    <Typography variant="caption" sx={{ color: "text.secondary", fontSize: "0.75rem" }}>
+                      {user.age}세 · {user.gender === "MALE" ? "남" : user.gender === "FEMALE" ? "여" : "-"}
+                    </Typography>
+                  )}
                 </TableCell>
+                {!compact && (
                 <TableCell>
                   <Typography
                     variant="body2"
@@ -194,9 +202,11 @@ export default function UserTableList({
                         : "-"}
                   </Typography>
                 </TableCell>
+                )}
                 <TableCell align="center">
                   <RankBadge rank={user.rank} />
                 </TableCell>
+                {!compact && (
                 <TableCell>
                   <Typography
                     variant="body2"
@@ -205,6 +215,8 @@ export default function UserTableList({
                     {user.universityName || "-"}
                   </Typography>
                 </TableCell>
+                )}
+                {!compact && (
                 <TableCell>
                   <Typography
                     variant="body2"
@@ -213,6 +225,7 @@ export default function UserTableList({
                     {user.department || "-"}
                   </Typography>
                 </TableCell>
+                )}
                 <TableCell align="center">
                   <Chip
                     label={`${user.pendingImages?.length || 0}장`}
@@ -224,11 +237,14 @@ export default function UserTableList({
                     }}
                   />
                 </TableCell>
+                {!compact && (
                 <TableCell>
                   <Typography variant="body2" sx={{ fontSize: "0.8rem" }}>
                     {user.mbti || "-"}
                   </Typography>
                 </TableCell>
+                )}
+                {!compact && (
                 <TableCell align="center">
                   <Chip
                     label={user.approved ? "아니오" : "예"}
@@ -240,11 +256,14 @@ export default function UserTableList({
                     }}
                   />
                 </TableCell>
+                )}
+                {!compact && (
                 <TableCell>
                   <Typography variant="body2" sx={{ fontSize: "0.8rem" }}>
                     {format(new Date(user.createdAt), "yyyy-MM-dd HH:mm")}
                   </Typography>
                 </TableCell>
+                )}
                 {onSkipUser && (
                   <TableCell align="center" sx={{ p: 0.5 }}>
                     <Tooltip title="건너뛰기">

--- a/app/admin/profile-review/page.tsx
+++ b/app/admin/profile-review/page.tsx
@@ -854,13 +854,13 @@ export default function ProfileReviewPage() {
       <Box
         sx={{
           display: "flex",
-          flexDirection: "column",
+          flexDirection: "row",
           gap: 2,
           height: "calc(100vh - 200px)",
         }}
       >
-        {/* 상단: 유저 테이블 */}
-        <Box sx={{ flex: "4", overflow: "auto", minHeight: 0 }}>
+        {/* 좌: 컴팩트 유저 테이블 (30%) */}
+        <Box sx={{ flex: "0 0 30%", overflow: "auto", minWidth: 0 }}>
           <UserTableList
             users={users}
             selectedUser={selectedUser}
@@ -872,11 +872,12 @@ export default function ProfileReviewPage() {
             selectedUserIds={selectedUserIds}
             onUserCheck={handleUserCheck}
             onSelectAllCheck={handleSelectAllCheck}
+            compact
           />
         </Box>
 
-        {/* 하단: 심사 패널 (전체 너비) */}
-        <Box sx={{ flex: "6", overflow: "auto", minHeight: 0 }}>
+        {/* 우: 심사 패널 (70%) */}
+        <Box sx={{ flex: 1, overflow: "auto", minWidth: 0 }}>
           <ImageReviewPanel
             user={selectedUser}
             onApprove={handleApproveUser}


### PR DESCRIPTION
## Summary
- 프로필 심사 페이지 레이아웃을 상하 분할(4:6)에서 **좌우 분할(30%:70%)**로 변경
- 좌측 컴팩트 유저 테이블: 6개 컬럼 숨김, 이름 하단에 나이/성별 병합
- 우측 심사 패널: 이미지 슬롯을 **가로 3열 그리드**로 배치, 정방형(1:1) 비율 유지
- 심사 참고 정보(선호도, 거절 이력 등) **Collapse**로 접기/펼치기 — 스크롤 최소화

## Test plan
- [ ] `/admin/profile-review` 접속하여 좌우 30:70 분할 확인
- [ ] 좌측 컴팩트 테이블에서 이름, Rank, 사진 수만 표시되는지 확인
- [ ] 우측 이미지 슬롯 3개가 가로 3열로 배치되는지 확인
- [ ] 이미지가 정방형(1:1) 비율인지 확인
- [ ] 이미지 클릭 시 확대 모달 동작 확인
- [ ] 심사 상세 정보 접기/펼치기 동작 확인
- [ ] Rank 선택 + 승인/반려 기능 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)