### PR TITLE
fix(admin-support-chat): resolved QA 전체 조회

### DIFF
--- a/app/admin/support-chat/components/SessionQueue.tsx
+++ b/app/admin/support-chat/components/SessionQueue.tsx
@@ -10,7 +10,6 @@ import {
   Alert,
   ButtonGroup,
   Button,
-  TablePagination,
 } from '@mui/material';
 import {
   FiberManualRecord as DotIcon,
@@ -32,9 +31,6 @@ interface SessionQueueProps {
   newSessionIds: Set<string>;
   onClearNewSessionIds: () => void;
   unreadMap: Record<string, number>;
-  resolvedPage: number;
-  resolvedTotal: number;
-  onResolvedPageChange: (page: number) => void;
 }
 
 const statusDotColor: Record<string, string> = {
@@ -158,9 +154,6 @@ export default function SessionQueue({
   newSessionIds,
   onClearNewSessionIds,
   unreadMap,
-  resolvedPage,
-  resolvedTotal,
-  onResolvedPageChange,
 }: SessionQueueProps) {
   const sessions = activeTab === 'active' ? activeSessions : resolvedSessions;
 
@@ -253,20 +246,6 @@ export default function SessionQueue({
           ))
         )}
       </Box>
-
-      {/* Resolved pagination */}
-      {activeTab === 'resolved' && (
-        <TablePagination
-          component="div"
-          count={resolvedTotal}
-          page={resolvedPage - 1}
-          onPageChange={(_e, newPage) => onResolvedPageChange(newPage + 1)}
-          rowsPerPage={20}
-          rowsPerPageOptions={[20]}
-          labelDisplayedRows={({ from, to, count }) => `${from}-${to} / ${count}`}
-          sx={{ borderTop: 1, borderColor: 'divider' }}
-        />
-      )}
     </Box>
   );
 }

--- a/app/admin/support-chat/hooks/useSessionPolling.ts
+++ b/app/admin/support-chat/hooks/useSessionPolling.ts
@@ -5,6 +5,8 @@ import supportChatService from '@/app/services/support-chat';
 import type { SupportSessionSummary } from '@/app/types/support-chat';
 
 const POLLING_INTERVAL = 30_000;
+const RESOLVED_FETCH_LIMIT = 100;
+const MAX_RESOLVED_PAGES = 200;
 
 interface StatusCounts {
   waiting: number;
@@ -21,9 +23,6 @@ interface UseSessionPollingReturn {
   newSessionIds: Set<string>;
   clearNewSessionIds: () => void;
   refresh: () => Promise<void>;
-  resolvedPage: number;
-  resolvedTotal: number;
-  setResolvedPage: (page: number) => void;
 }
 
 export function useSessionPolling(): UseSessionPollingReturn {
@@ -33,8 +32,6 @@ export function useSessionPolling(): UseSessionPollingReturn {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [newSessionIds, setNewSessionIds] = useState<Set<string>>(new Set());
-  const [resolvedPage, setResolvedPage] = useState(1);
-  const [resolvedTotal, setResolvedTotal] = useState(0);
 
   const prevWaitingIdsRef = useRef<Set<string>>(new Set());
   const isFirstFetchRef = useRef(true);
@@ -75,16 +72,54 @@ export function useSessionPolling(): UseSessionPollingReturn {
     return combined;
   }, []);
 
+  const fetchAllResolvedSessions = useCallback(async () => {
+    let page = 1;
+    let totalPages = 1;
+    let total = 0;
+    const aggregated: SupportSessionSummary[] = [];
+
+    while (page <= totalPages && page <= MAX_RESOLVED_PAGES) {
+      const res = await supportChatService.getSessions({
+        status: 'resolved',
+        page,
+        limit: RESOLVED_FETCH_LIMIT,
+      });
+
+      aggregated.push(...res.sessions);
+      total = res.pagination.total || total;
+
+      const pageLimit = res.pagination.limit || RESOLVED_FETCH_LIMIT;
+      const derivedTotalPages =
+        res.pagination.totalPages ||
+        Math.ceil((res.pagination.total || aggregated.length) / Math.max(pageLimit, 1)) ||
+        1;
+      totalPages = Math.max(totalPages, derivedTotalPages);
+
+      if (res.sessions.length === 0 || page >= derivedTotalPages) {
+        break;
+      }
+      page += 1;
+    }
+
+    if (totalPages > MAX_RESOLVED_PAGES) {
+      console.warn(`resolved 세션 조회가 최대 페이지(${MAX_RESOLVED_PAGES})를 초과했습니다.`);
+    }
+
+    const uniqueSessions = Array.from(
+      new Map(aggregated.map((session) => [session.sessionId, session])).values()
+    );
+
+    return {
+      sessions: uniqueSessions,
+      total: total || uniqueSessions.length,
+    };
+  }, []);
+
   const fetchResolved = useCallback(async () => {
-    const res = await supportChatService.getSessions({
-      status: 'resolved',
-      page: resolvedPage,
-      limit: 20,
-    });
+    const res = await fetchAllResolvedSessions();
     setResolvedSessions(res.sessions);
-    setResolvedTotal(res.pagination.total);
-    setStatusCounts((prev) => ({ ...prev, resolved: res.pagination.total }));
-  }, [resolvedPage]);
+    setStatusCounts((prev) => ({ ...prev, resolved: res.total }));
+  }, [fetchAllResolvedSessions]);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -121,8 +156,5 @@ export function useSessionPolling(): UseSessionPollingReturn {
     newSessionIds,
     clearNewSessionIds,
     refresh,
-    resolvedPage,
-    resolvedTotal,
-    setResolvedPage,
   };
 }

--- a/app/admin/support-chat/page.tsx
+++ b/app/admin/support-chat/page.tsx
@@ -45,9 +45,6 @@ export default function SupportChatPage() {
     newSessionIds,
     clearNewSessionIds,
     refresh,
-    resolvedPage,
-    resolvedTotal,
-    setResolvedPage,
   } = useSessionPolling();
 
   // Track unread messages
@@ -122,9 +119,6 @@ export default function SupportChatPage() {
               newSessionIds={newSessionIds}
               onClearNewSessionIds={clearNewSessionIds}
               unreadMap={unreadMap}
-              resolvedPage={resolvedPage}
-              resolvedTotal={resolvedTotal}
-              onResolvedPageChange={setResolvedPage}
             />
           </Box>
         ) : (
@@ -171,9 +165,6 @@ export default function SupportChatPage() {
           newSessionIds={newSessionIds}
           onClearNewSessionIds={clearNewSessionIds}
           unreadMap={unreadMap}
-          resolvedPage={resolvedPage}
-          resolvedTotal={resolvedTotal}
-          onResolvedPageChange={setResolvedPage}
         />
         <ChatPanel
           sessionId={selectedSessionId}


### PR DESCRIPTION
## 변경 사항\n- support-chat 해결 탭에서 resolved 세션을 모든 페이지 순회 조회하도록 변경\n- 해결 탭 페이지네이션 제거 후 전체 resolved QA 표시\n- 관련 props 정리\n\n## 배경\n- 어드민 QA에서 최근 일부(7개)만 보이고 과거 해결 문의가 보이지 않는 이슈 수정\n\n## 확인 포인트\n- /admin/support-chat > 해결 탭에서 과거 문의 포함 전체 목록 노출\n