### PR TITLE
fix(region-filter): 동적 클러스터 데이터 로딩 및 버그 수정

### DIFF
--- a/app/admin/profile-review/page.tsx
+++ b/app/admin/profile-review/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import {
   Box,
   Typography,
@@ -32,7 +32,7 @@ import UserTableList from "./components/UserTableList";
 import ImageReviewPanel from "./components/ImageReviewPanel";
 import RejectReasonModal from "./components/RejectReasonModal";
 import ReviewHistoryTab from "./components/ReviewHistoryTab";
-import { REGION_MAP } from "../sales/constants/regions";
+import { useClusterOptions, getIndividualRegionLabel } from "@/components/admin/common/RegionFilter";
 
 export interface PendingProfileImage {
   id: string;
@@ -178,10 +178,7 @@ const clearAllSkippedUsers = (): void => {
   localStorage.removeItem(SKIPPED_USERS_KEY);
 };
 
-// 지역 옵션 (전체 제외)
-const REGION_OPTIONS = Object.entries(REGION_MAP)
-  .filter(([code]) => code !== "all")
-  .map(([code, name]) => ({ value: code, label: name }));
+// 지역 옵션은 useClusterOptions 훅에서 동적으로 가져옴 (컴포넌트 내부에서 사용)
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -204,6 +201,11 @@ function TabPanel({ children, value, index, ...other }: TabPanelProps) {
 }
 
 export default function ProfileReviewPage() {
+  const { individualOptions } = useClusterOptions();
+  const REGION_OPTIONS = useMemo(
+    () => individualOptions.filter(opt => opt.value !== 'ALL'),
+    [individualOptions]
+  );
   const [activeTab, setActiveTab] = useState(0);
   const [users, setUsers] = useState<PendingUser[]>([]);
   const [selectedUser, setSelectedUser] = useState<PendingUser | null>(null);
@@ -872,7 +874,7 @@ export default function ProfileReviewPage() {
               )}
               {filters.region && (
                 <Chip
-                  label={`지역: ${REGION_MAP[filters.region] || filters.region}`}
+                  label={`지역: ${getIndividualRegionLabel(filters.region)}`}
                   size="small"
                   onDelete={() => handleFilterChange("region", undefined)}
                 />

--- a/components/admin/common/RegionFilter.tsx
+++ b/components/admin/common/RegionFilter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
   FormControl,
   InputLabel,
@@ -12,36 +12,109 @@ import {
   Switch,
   Typography
 } from '@mui/material';
+import { useCountry } from '@/contexts/CountryContext';
+import AdminService from '@/app/services/admin';
+import type { AdminClusterItem } from '@/types/admin';
 
-// 지역 타입 정의 (클러스터 기반)
-export type Region = 'ALL' | 'DJN' | 'SJG' | 'CAN' | 'BSN' | 'DGU' | 'ICN' | 'CJU' | 'GJJ' | 'GHE' | 'SEL' | 'KYG' | 'GWJ';
+// 지역 타입 - 백엔드 API에서 동적으로 결정되므로 string 타입 사용
+export type Region = string;
 
-const CLUSTER_REGION_OPTIONS = [
-  { value: 'ALL', label: '전체 지역' },
-  { value: 'DJN', label: '대전/공주 클러스터' },
-  { value: 'SJG', label: '청주/세종 클러스터' },
-  { value: 'CAN', label: '천안 클러스터' },
-  { value: 'BSN', label: '부산/김해 클러스터' },
-  { value: 'ICN', label: '인천/서울/경기 클러스터' },
-  { value: 'DGU', label: '대구' },
-  { value: 'GWJ', label: '광주' }
-] as const;
+interface RegionOption {
+  value: string;
+  label: string;
+}
 
-const INDIVIDUAL_REGION_OPTIONS = [
-  { value: 'ALL', label: '전체 지역' },
-  { value: 'DJN', label: '대전' },
-  { value: 'SJG', label: '세종' },
-  { value: 'CJU', label: '청주' },
-  { value: 'GJJ', label: '공주' },
-  { value: 'BSN', label: '부산' },
-  { value: 'GHE', label: '김해' },
-  { value: 'DGU', label: '대구' },
-  { value: 'ICN', label: '인천' },
-  { value: 'SEL', label: '서울' },
-  { value: 'KYG', label: '경기' },
-  { value: 'CAN', label: '천안' },
-  { value: 'GWJ', label: '광주' }
-] as const;
+const ALL_OPTION: RegionOption = { value: 'ALL', label: '전체 지역' };
+
+// Fix 1: 국가별 캐시 분리 - Map<country, data>
+const _cacheByCountry = new Map<string, AdminClusterItem[]>();
+const _promiseByCountry = new Map<string, Promise<AdminClusterItem[]>>();
+
+function fetchClusters(country: string): Promise<AdminClusterItem[]> {
+  const cached = _cacheByCountry.get(country);
+  if (cached) return Promise.resolve(cached);
+
+  const pending = _promiseByCountry.get(country);
+  if (pending) return pending;
+
+  const promise = AdminService.universities.getClusters()
+    .then(data => {
+      _cacheByCountry.set(country, data);
+      return data;
+    })
+    .catch((err) => {
+      _promiseByCountry.delete(country);
+      throw err; // Fix 2: 에러를 전파하여 호출부에서 처리
+    });
+
+  _promiseByCountry.set(country, promise);
+  return promise;
+}
+
+// Fix 3: 클러스터 ID를 value로 사용 - regions[0].code 의존 제거
+function buildClusterOptions(clusters: AdminClusterItem[]): RegionOption[] {
+  return [
+    ALL_OPTION,
+    ...clusters.map(c => ({
+      value: c.id,
+      label: c.name,
+    })),
+  ];
+}
+
+function buildIndividualOptions(clusters: AdminClusterItem[]): RegionOption[] {
+  const regions = clusters.flatMap(c => c.regions);
+  return [
+    ALL_OPTION,
+    ...regions.map(r => ({ value: r.code, label: r.name })),
+  ];
+}
+
+/** 클러스터 데이터를 API에서 가져와 옵션 목록을 반환하는 훅 */
+export function useClusterOptions() {
+  const { country } = useCountry();
+  const [clusters, setClusters] = useState<AdminClusterItem[]>(() => _cacheByCountry.get(country) || []);
+  const [loading, setLoading] = useState(() => !_cacheByCountry.has(country));
+  const [error, setError] = useState<Error | null>(null); // Fix 2: 에러 상태 노출
+
+  useEffect(() => {
+    let cancelled = false;
+
+    // 국가 변경 시 즉시 캐시된 데이터로 전환하거나 로딩 시작
+    const cached = _cacheByCountry.get(country);
+    if (cached) {
+      setClusters(cached);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    fetchClusters(country)
+      .then(data => {
+        if (!cancelled) {
+          setClusters(data);
+          setLoading(false);
+        }
+      })
+      .catch(err => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setClusters([]);
+          setLoading(false);
+        }
+      });
+
+    return () => { cancelled = true; };
+  }, [country]); // Fix 1: country 변경 시 재패칭
+
+  const clusterOptions = useMemo(() => buildClusterOptions(clusters), [clusters]);
+  const individualOptions = useMemo(() => buildIndividualOptions(clusters), [clusters]);
+
+  return { clusters, clusterOptions, individualOptions, loading, error };
+}
 
 interface RegionFilterProps {
   value: Region;
@@ -68,8 +141,10 @@ export default function RegionFilter({
   fullWidth = false,
   sx = {}
 }: RegionFilterProps) {
-  const handleChange = (event: SelectChangeEvent<Region>) => {
-    onChange(event.target.value as Region);
+  const { clusterOptions, individualOptions, loading, error } = useClusterOptions();
+
+  const handleChange = (event: SelectChangeEvent<string>) => {
+    onChange(event.target.value);
   };
 
   const handleClusterToggle = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -79,7 +154,8 @@ export default function RegionFilter({
     }
     onChange('ALL');
   };
-  const regionOptions = useCluster ? CLUSTER_REGION_OPTIONS : INDIVIDUAL_REGION_OPTIONS;
+
+  const regionOptions = useCluster ? clusterOptions : individualOptions;
 
   return (
     <Box sx={sx}>
@@ -106,7 +182,8 @@ export default function RegionFilter({
         size={size}
         variant={variant}
         fullWidth={fullWidth}
-        disabled={disabled}
+        disabled={disabled || loading}
+        error={!!error}
       >
         <InputLabel id="region-filter-label">지역</InputLabel>
         <Select
@@ -123,6 +200,11 @@ export default function RegionFilter({
           ))}
         </Select>
       </FormControl>
+      {error && (
+        <Typography variant="caption" color="error" sx={{ mt: 0.5, display: 'block' }}>
+          지역 목록을 불러오지 못했습니다
+        </Typography>
+      )}
     </Box>
   );
 }
@@ -138,7 +220,6 @@ export function useRegionFilter(initialRegion: Region = 'ALL', initialUseCluster
 
   const handleClusterModeChange = (newUseCluster: boolean) => {
     setUseCluster(newUseCluster);
-
     setRegion('ALL');
   };
 
@@ -161,10 +242,20 @@ export function useRegionFilter(initialRegion: Region = 'ALL', initialUseCluster
   };
 }
 
+// 캐시 기반 라벨 조회 - 현재 국가의 캐시에서 조회
 export const getRegionLabel = (region: Region, useCluster: boolean = true): string => {
-  const options = useCluster ? CLUSTER_REGION_OPTIONS : INDIVIDUAL_REGION_OPTIONS;
+  if (region === 'ALL') return '전체 지역';
+
+  // 현재 localStorage의 국가로 캐시 조회
+  const country = (typeof window !== 'undefined' && localStorage.getItem('admin_selected_country')) || 'kr';
+  const cache = _cacheByCountry.get(country);
+  if (!cache || cache.length === 0) return region;
+
+  const options = useCluster
+    ? buildClusterOptions(cache)
+    : buildIndividualOptions(cache);
   const option = options.find(opt => opt.value === region);
-  return option?.label || '전체 지역';
+  return option?.label || region;
 };
 
 export const getClusterRegionLabel = (region: Region): string => {


### PR DESCRIPTION
## Summary
- RegionFilter 컴포넌트를 하드코딩에서 백엔드 API(`/admin/universities/clusters`) 기반 동적 로딩으로 전환
- 국가별 캐시 분리로 KR/JP 전환 시 올바른 클러스터 데이터 제공
- API 실패 시 에러 상태 전파 및 사용자 피드백 UI 추가
- 클러스터 옵션 value를 `regions[0].code`에서 안정적인 `cluster.id`로 변경
- profile-review 페이지에서 하드코딩 `REGION_MAP` 제거, 동적 옵션 사용

## Changed Files
- `components/admin/common/RegionFilter.tsx` - 핵심 수정 (3건 버그 fix + 동적 로딩)
- `app/admin/profile-review/page.tsx` - 하드코딩 제거, 동적 옵션 전환

## Test plan
- [ ] KR 모드에서 지역 필터 드롭다운에 올바른 클러스터 목록 표시 확인
- [ ] JP 모드 전환 후 일본 클러스터 목록으로 갱신 확인
- [ ] KR ↔ JP 반복 전환 시 캐시 정상 동작 확인
- [ ] API 실패 시뮬레이션 시 에러 메시지 표시 확인
- [ ] 회원 통계 페이지에서 클러스터/개별 지역 토글 정상 동작 확인
- [ ] 프로필 심사 페이지에서 지역 필터 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)