### PR TITLE
feat(admin): 좋아요/채팅 관리 이름 검색 기능 추가

### DIFF
--- a/app/admin/chat/components/ChatManagementTab.tsx
+++ b/app/admin/chat/components/ChatManagementTab.tsx
@@ -27,6 +27,8 @@ import {
   Card,
   Typography,
   ButtonGroup,
+  TextField,
+  InputAdornment,
 } from '@mui/material';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
@@ -37,6 +39,7 @@ import {
   Close as CloseIcon,
   AccessTime as AccessTimeIcon,
   Download as DownloadIcon,
+  Search as SearchIcon,
 } from '@mui/icons-material';
 import UserDetailModal from '@/components/admin/appearance/UserDetailModal';
 import chatService, {
@@ -85,6 +88,7 @@ export default function ChatManagementTab() {
   const [imagePreviewOpen, setImagePreviewOpen] = useState(false);
   const [previewImageUrl, setPreviewImageUrl] = useState<string>('');
 
+  const [searchName, setSearchName] = useState('');
   const [error, setError] = useState<string>('');
   const [csvExporting, setCsvExporting] = useState(false);
 
@@ -97,6 +101,10 @@ export default function ChatManagementTab() {
         page: page + 1,
         limit: rowsPerPage
       };
+
+      if (searchName.trim()) {
+        params.searchName = searchName.trim();
+      }
 
       if (preset) {
         params.preset = preset;
@@ -245,6 +253,22 @@ export default function ChatManagementTab() {
 
       <Paper sx={{ p: 2, mb: 2 }}>
         <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', flexWrap: 'wrap', mb: 2 }}>
+          <TextField
+            size="small"
+            placeholder="사용자 이름 검색"
+            value={searchName}
+            onChange={(e) => setSearchName(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') { setPage(0); fetchChatRooms(); } }}
+            sx={{ minWidth: 180 }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon fontSize="small" color="action" />
+                </InputAdornment>
+              ),
+            }}
+          />
+
           <LocalizationProvider dateAdapter={AdapterDateFns}>
             <DatePicker
               label="시작 날짜"

--- a/app/admin/likes/page.tsx
+++ b/app/admin/likes/page.tsx
@@ -23,6 +23,8 @@ import {
   Avatar,
   Tooltip,
   IconButton,
+  TextField,
+  InputAdornment,
 } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -30,6 +32,7 @@ import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { ko } from 'date-fns/locale';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import RefreshIcon from '@mui/icons-material/Refresh';
+import SearchIcon from '@mui/icons-material/Search';
 import AdminService from '@/app/services/admin';
 import type { LikeDetail, AdminLikesParams, LikeStatus } from '@/types/admin';
 
@@ -57,6 +60,7 @@ export default function LikesManagementPage() {
   const [totalPages, setTotalPages] = useState(1);
   const [totalItems, setTotalItems] = useState(0);
 
+  const [searchName, setSearchName] = useState('');
   const [filters, setFilters] = useState<Filters>({
     status: 'ALL',
     hasLetter: 'ALL',
@@ -79,6 +83,9 @@ export default function LikesManagementPage() {
         sortOrder: filters.sortOrder,
       };
 
+      if (searchName.trim()) {
+        params.searchName = searchName.trim();
+      }
       if (filters.status !== 'ALL') {
         params.status = filters.status;
       }
@@ -120,6 +127,7 @@ export default function LikesManagementPage() {
   };
 
   const handleReset = () => {
+    setSearchName('');
     setFilters({
       status: 'ALL',
       hasLetter: 'ALL',
@@ -200,6 +208,22 @@ export default function LikesManagementPage() {
         {/* 필터 영역 */}
         <Paper sx={{ p: 2, mb: 3 }}>
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2, alignItems: 'center' }}>
+            <TextField
+              size="small"
+              placeholder="이름 검색"
+              value={searchName}
+              onChange={(e) => setSearchName(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleSearch(); }}
+              sx={{ minWidth: 180 }}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon fontSize="small" color="action" />
+                  </InputAdornment>
+                ),
+              }}
+            />
+
             <FormControl size="small" sx={{ minWidth: 120 }}>
               <InputLabel>상태</InputLabel>
               <Select

--- a/app/services/chat.ts
+++ b/app/services/chat.ts
@@ -49,6 +49,7 @@ export interface ChatRoomsParams {
   startDate?: string;
   endDate?: string;
   preset?: DatePreset;
+  searchName?: string;
   page?: number;
   limit?: number;
 }
@@ -117,6 +118,7 @@ class ChatService {
           startDate: params.startDate,
           endDate: params.endDate,
           preset: params.preset,
+          searchName: params.searchName,
           page: params.page || 1,
           limit: params.limit || 20
         }

--- a/types/admin.ts
+++ b/types/admin.ts
@@ -718,6 +718,7 @@ export interface AdminLikesParams {
   isMutualLike?: boolean;
   senderUserId?: string;
   forwardUserId?: string;
+  searchName?: string;
   startDate?: string;
   endDate?: string;
   sortBy?: 'createdAt' | 'viewedAt' | 'mutualLikeAt';


### PR DESCRIPTION
## Summary
- 좋아요 관리 페이지에 보낸 사람/받은 사람 이름 검색 TextField 추가
- 채팅 관리 탭에 사용자 이름 검색 TextField 추가
- `AdminLikesParams`, `ChatRoomsParams` 타입에 `searchName` 파라미터 추가
- 채팅 서비스 레이어에서 `searchName`이 실제 API 요청에 전달되도록 수정

## Test plan
- [ ] 좋아요 관리에서 이름 입력 후 Enter/검색 버튼으로 검색 동작 확인
- [ ] 좋아요 관리에서 초기화 버튼 클릭 시 검색어 리셋 확인
- [ ] 채팅 관리에서 이름 입력 후 Enter로 검색 동작 확인
- [ ] 입력 중 불필요한 API 호출이 발생하지 않는지 확인
- [ ] 백엔드 `searchName` 파라미터 지원 후 실제 필터링 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)