### PR TITLE
fix(admin): 매칭 내역 이름 검색 Enter 키 지원 추가

### DIFF
--- a/app/admin/matching-management/page.tsx
+++ b/app/admin/matching-management/page.tsx
@@ -695,6 +695,7 @@ export default function MatchingManagement() {
                   type="text"
                   value={historySearchName}
                   onChange={(e) => setHistorySearchName(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') handleSearchMatchingHistory(); }}
                   placeholder="이름으로 검색"
                   className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
                 />
@@ -973,6 +974,7 @@ export default function MatchingManagement() {
                   type="text"
                   value={failureSearchName}
                   onChange={(e) => setFailureSearchName(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') handleSearchMatchingFailures(); }}
                   placeholder="이름으로 검색"
                   className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
                 />


### PR DESCRIPTION
## Summary
- 매칭 관리 페이지의 이름 검색 입력란에서 Enter 키로 검색 실행되도록 수정
- 매칭 내역 조회 / 매칭 실패 내역 두 곳에 onKeyDown 핸들러 추가

## 참고: 매칭 내역 이름 검색 근본 원인
- 백엔드(`sometimes-api`)의 `feature/admin-api-migration` 브랜치에 `match-history`, `matcher-history`, `like-history` 엔드포인트가 있으나 **dev/master에 머지되지 않은 상태**
- 해당 브랜치 머지 및 배포가 필요합니다
- 프론트엔드 파라미터(`name`)는 백엔드 `@Query('name')`과 일치하여 정상

## Test plan
- [ ] 매칭 내역 조회 탭에서 이름 입력 후 Enter 키로 검색 동작 확인
- [ ] 매칭 실패 내역 탭에서 이름 입력 후 Enter 키로 검색 동작 확인
- [ ] 백엔드 `feature/admin-api-migration` 브랜치 머지 후 이름 검색 필터링 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)