### PR TITLE
fix(community): 어드민 커뮤니티 댓글 수 미표시 및 좋아요 수 불일치 수정

### DIFF
--- a/app/admin/community/page.tsx
+++ b/app/admin/community/page.tsx
@@ -276,6 +276,7 @@ function ArticleList() {
 			// 게시글 상세 정보 구성
 			const articleDetail = {
 				...selectedArticle,
+				commentCount: commentsResponse?.meta?.totalItems ?? selectedArticle.commentCount ?? commentsWithAuthor.length,
 				likeCount: selectedArticle.likeCount ?? 0,
 				author: {
 					id: selectedArticle.author?.id ?? selectedArticle.userId ?? '',

--- a/app/services/community.ts
+++ b/app/services/community.ts
@@ -101,6 +101,24 @@ export interface Category {
 	displayName: string;
 }
 
+// 백엔드 응답을 Article 인터페이스로 정규화
+const normalizeArticle = (a: any): Article => ({
+	...a,
+	content: a.contentPreview ?? a.content ?? '',
+	commentCount:
+		a.commentCount ?? a.comment_count ?? a.comments_count ??
+		(Array.isArray(a.comments) ? a.comments.length : 0),
+	likeCount:
+		a.likeCount ?? a.like_count ?? a.likes_count ??
+		(Array.isArray(a.likes) ? a.likes.length : 0),
+	reportCount:
+		a.reportCount ?? a.report_count ?? a.reports_count ??
+		(Array.isArray(a.reports) ? a.reports.length : 0),
+	author: a.authorName
+		? { id: a.authorId, name: a.authorName }
+		: a.author ?? undefined,
+});
+
 // 커뮤니티 관리 API 서비스
 const communityService = {
 	// 게시글 목록 조회
@@ -151,11 +169,7 @@ const communityService = {
 
 			// API 응답 구조에 맞게 데이터 반환 (백엔드는 articles/pagination 구조 사용)
 			const rawArticles = response.data.articles ?? [];
-			const articles = rawArticles.map((a: any) => ({
-				...a,
-				content: a.contentPreview ?? a.content ?? '',
-				author: a.authorName ? { id: a.authorId, name: a.authorName } : undefined,
-			}));
+			const articles = rawArticles.map(normalizeArticle);
 			const pagination = response.data.pagination;
 			return {
 				items: articles,
@@ -203,13 +217,15 @@ const communityService = {
 			// 댓글 정보 가져오기
 			const commentsResponse = await axiosServer.get(`/admin/community/comments`, {
 				params: {
+					articleId: id,
 					article_id: id,
 				},
 			});
 
 			// 게시글 상세 정보 구성
+			const normalized = normalizeArticle(article);
 			const articleDetail: ArticleDetail = {
-				...article,
+				...normalized,
 				comments: commentsResponse.data?.comments ?? [],
 				reports: [],
 			};


### PR DESCRIPTION
## Summary
- 어드민 커뮤니티 관리에서 게시글별 댓글 수가 표시되지 않고, 좋아요 수도 실제와 다르게 반영되는 버그 수정
- 백엔드 응답 필드명 불일치(camelCase/snake_case/배열)를 일관되게 처리하는 `normalizeArticle` 정규화 함수 도입
- 댓글 API 파라미터명 통일 및 상세 보기 댓글 수 정확도 개선

## Test plan
- [ ] 어드민 > 커뮤니티 관리 진입 후 게시글 목록에서 댓글 수 컬럼에 숫자(0 포함) 표시 확인
- [ ] 좋아요 수가 실제 데이터와 일치하는지 확인
- [ ] 게시글 상세 보기에서 댓글/좋아요 칩 수치가 목록과 동일한지 교차 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)