### PR TITLE
fix(member-stats): 가입 추이 기간 변경 시 지역 필터 유지

### DIFF
--- a/app/admin/dashboard/member-stats/page.tsx
+++ b/app/admin/dashboard/member-stats/page.tsx
@@ -386,6 +386,7 @@ export default function MemberStatsDashboard() {
               <SignupStatsDashboard
                 region={getRegionParam()}
                 includeDeleted={getIncludeDeletedParam()}
+                useCluster={getUseClusterParam()}
               />
             </CardContent>
           </Card>

--- a/components/admin/dashboard/SignupStatsDashboard.tsx
+++ b/components/admin/dashboard/SignupStatsDashboard.tsx
@@ -42,6 +42,7 @@ interface MonthlySignupTrendItem {
 interface SignupStatsDashboardProps {
 	region?: string;
 	includeDeleted?: boolean;
+	useCluster?: boolean;
 }
 
 type TabType = 'daily' | 'weekly' | 'monthly' | 'custom';
@@ -139,6 +140,7 @@ function StatCard({ label, value, color, bgColor, subValue, subLabel }: StatCard
 export default function SignupStatsDashboard({
 	region,
 	includeDeleted = false,
+	useCluster,
 }: SignupStatsDashboardProps) {
 	const [activeTab, setActiveTab] = useState<TabType>('daily');
 	const [dailyData, setDailyData] = useState<DailySignupTrendItem[]>([]);
@@ -266,6 +268,7 @@ export default function SignupStatsDashboard({
 					const dailyResponse = await AdminService.stats.getDailySignupTrend(
 						region,
 						includeDeleted,
+						useCluster,
 					);
 					if (dailyResponse?.data?.length > 0) {
 						setDailyData(dailyResponse.data);
@@ -280,6 +283,7 @@ export default function SignupStatsDashboard({
 					const weeklyResponse = await AdminService.stats.getWeeklySignupTrend(
 						region,
 						includeDeleted,
+						useCluster,
 					);
 					if (weeklyResponse?.data?.length > 0) {
 						setWeeklyData(weeklyResponse.data);
@@ -294,6 +298,7 @@ export default function SignupStatsDashboard({
 					const monthlyResponse = await AdminService.stats.getMonthlySignupTrend(
 						region,
 						includeDeleted,
+						useCluster,
 					);
 					if (monthlyResponse?.data?.length > 0) {
 						setMonthlyData(monthlyResponse.data);
@@ -316,7 +321,7 @@ export default function SignupStatsDashboard({
 		fetchTrendData();
 		const interval = setInterval(fetchTrendData, 5 * 60 * 1000);
 		return () => clearInterval(interval);
-	}, [region, includeDeleted]);
+	}, [region, includeDeleted, useCluster]);
 
 	const isDateRangeValid = () => {
 		if (!startDate || !endDate) return false;
@@ -344,6 +349,7 @@ export default function SignupStatsDashboard({
 				formattedEndDate,
 				region,
 				includeDeleted,
+				useCluster,
 			);
 
 			let count = 0;
@@ -387,6 +393,7 @@ export default function SignupStatsDashboard({
 				formattedEndDate,
 				region,
 				includeDeleted,
+				useCluster,
 			);
 
 			let trendDataArray: any[] = [];
@@ -456,7 +463,7 @@ export default function SignupStatsDashboard({
 		if (startDate && endDate && isDateRangeValid()) {
 			fetchCustomPeriodData();
 		}
-	}, []);
+	}, [region, includeDeleted, useCluster]);
 
 	const currentChartData = useMemo((): ChartDataItem[] => {
 		switch (activeTab) {


### PR DESCRIPTION
## Summary
- 가입 추이(SignupStatsDashboard) 컴포넌트에서 기간 설정 변경 시 지역 필터가 초기화되는 버그 수정
- 커스텀 기간 탭의 useEffect 의존성 배열이 비어있어 region 변경 시 데이터가 갱신되지 않던 문제 해결
- useCluster prop 누락으로 클러스터 지역 필터링이 API에 전달되지 않던 문제 해결

## Changes
- `SignupStatsDashboard`: useCluster prop 추가, 모든 API 호출(5개)에 useCluster 전달, useEffect 의존성 배열 수정
- `member-stats/page.tsx`: SignupStatsDashboard에 useCluster prop 전달

## Root Cause
1. 커스텀 기간 useEffect의 의존성 배열이 `[]`로 설정되어 region/includeDeleted 변경 시 재조회되지 않음
2. useCluster prop이 SignupStatsDashboard에 전달되지 않아 클러스터 지역 코드가 백엔드에 올바르게 전달되지 않음

## Test plan
- [ ] 어드민 > 회원 통계 > 가입 추이에서 특정 지역 선택 후 탭(일별/주별/월별/기간별) 전환 시 지역 필터 유지 확인
- [ ] 기간별 탭에서 날짜 변경 후 조회 시 선택된 지역 데이터가 정상 조회되는지 확인
- [ ] 클러스터 모드 토글 시 지역이 전체로 초기화되는 기존 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)