### PR TITLE
fix(region-filter): 클러스터 필터 0명 버그 수정

### DIFF
--- a/components/admin/common/RegionFilter.tsx
+++ b/components/admin/common/RegionFilter.tsx
@@ -51,12 +51,13 @@ function fetchClusters(country: string): Promise<AdminClusterItem[]> {
   return promise;
 }
 
-// Fix 3: 클러스터 ID를 value로 사용 - regions[0].code 의존 제거
+// 클러스터 옵션 value는 첫 번째 지역 코드 사용 (백엔드 stats API가 지역 코드를 기대)
+// regions가 비어있는 경우 c.id를 폴백으로 사용
 function buildClusterOptions(clusters: AdminClusterItem[]): RegionOption[] {
   return [
     ALL_OPTION,
     ...clusters.map(c => ({
-      value: c.id,
+      value: c.regions[0]?.code ?? c.id,
       label: c.name,
     })),
   ];


### PR DESCRIPTION
## Summary
- 회원통계 페이지에서 클러스터 필터 선택 시 모든 클러스터가 0명으로 표시되던 버그 수정
- `buildClusterOptions`의 value를 `c.id`(SEOUL_CLUSTER 등)에서 `regions[0]?.code`(ICN, DJN 등)로 변경
- 백엔드 stats API가 지역 코드를 기대하므로 클러스터 ID로는 매칭 불가했던 문제 해결

## Test plan
- [ ] 회원통계 페이지에서 클러스터 필터 선택 시 정상 유저 수 표시 확인
- [ ] 전체 지역 선택 시 기존과 동일하게 동작하는지 확인
- [ ] 개별 지역 모드 전환 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)