### PR TITLE
fix(admin-community): fetch report data and normalize counts

### DIFF
--- a/app/admin/community/page.tsx
+++ b/app/admin/community/page.tsx
@@ -273,17 +273,29 @@ function ArticleList() {
 					};
 				}) ?? [];
 
+			// 게시글 ID를 이용해 신고 정보 가져오기
+			let articleReports: any[] = [];
+			try {
+				const reportsResponse = await communityService.getReports('article', 'all', 1, 100);
+				articleReports = (reportsResponse?.items ?? []).filter(
+					(r: any) => r.targetId === id || r.postId === id
+				);
+			} catch (err) {
+				console.error('신고 데이터 조회 실패:', err);
+			}
+
 			// 게시글 상세 정보 구성
 			const articleDetail = {
 				...selectedArticle,
-				commentCount: commentsResponse?.meta?.totalItems ?? selectedArticle.commentCount ?? commentsWithAuthor.length,
+				commentCount: commentsResponse?.meta?.totalItems ?? commentsWithAuthor.length ?? selectedArticle.commentCount ?? 0,
 				likeCount: selectedArticle.likeCount ?? 0,
+				reportCount: articleReports.length || selectedArticle.reportCount || 0,
 				author: {
 					id: selectedArticle.author?.id ?? selectedArticle.userId ?? '',
 					name: selectedArticle.author?.name ?? selectedArticle.nickname ?? '익명',
 				},
 				comments: commentsWithAuthor,
-				reports: [],
+				reports: articleReports,
 			};
 
 			console.log('게시글 상세 정보:', articleDetail);

--- a/app/services/community.ts
+++ b/app/services/community.ts
@@ -106,13 +106,13 @@ const normalizeArticle = (a: any): Article => ({
 	...a,
 	content: a.contentPreview ?? a.content ?? '',
 	commentCount:
-		a.commentCount ?? a.comment_count ?? a.comments_count ??
+		a.commentCount ?? a.comment_count ?? a.comments_count ?? a.commentsCount ??
 		(Array.isArray(a.comments) ? a.comments.length : 0),
 	likeCount:
-		a.likeCount ?? a.like_count ?? a.likes_count ??
+		a.likeCount ?? a.like_count ?? a.likes_count ?? a.likesCount ??
 		(Array.isArray(a.likes) ? a.likes.length : 0),
 	reportCount:
-		a.reportCount ?? a.report_count ?? a.reports_count ??
+		a.reportCount ?? a.report_count ?? a.reports_count ?? a.reportsCount ??
 		(Array.isArray(a.reports) ? a.reports.length : 0),
 	author: a.authorName
 		? { id: a.authorId, name: a.authorName }


### PR DESCRIPTION
## Summary
- 게시글 상세 모달에서 신고 데이터를 실제 API로 fetch (기존: `reports: []` 하드코딩)
- `normalizeArticle()`에 `commentCount`, `likeCount`, `reportCount` 필드명 variant fallback 체인 추가

## Test plan
- [ ] 커뮤니티 관리 페이지에서 댓글/좋아요/신고 수가 정상 표시되는지 확인
- [ ] 게시글 상세 모달에서 신고 내역이 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)