### PR TITLE
fix: remove duplicate articleReports declaration causing build failure

### DIFF
--- a/app/admin/community/page.tsx
+++ b/app/admin/community/page.tsx
@@ -258,15 +258,6 @@ function ArticleList() {
 
 			// 게시글 ID를 이용해 댓글 정보 가져오기
 			const commentsResponse = await communityService.getComments(id);
-			let articleReports: any[] = [];
-
-			try {
-				const reportsResponse = await communityService.getReports('article', 'all', 1, 100);
-				articleReports =
-					reportsResponse?.items?.filter((report: any) => report.targetId === id || report.target_id === id) ?? [];
-			} catch (reportError) {
-				console.error('게시글 신고 내역 조회 중 오류:', reportError);
-			}
 
 			console.log('댓글 원본 데이터:', commentsResponse?.items);
 


### PR DESCRIPTION
## Summary
- 머지 시 `articleReports` 변수가 두 번 선언되어 Vercel 빌드 실패
- 이전 버전의 중복 선언 블록 제거, 개선된 버전만 유지

## Test plan
- [ ] Vercel 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)