### PR TITLE
fix(dashboard): 긴급 처리 필요 패널 수치 불일치 버그 수정

### DIFF
--- a/app/admin/dashboard/components/ActionRequired.tsx
+++ b/app/admin/dashboard/components/ActionRequired.tsx
@@ -9,14 +9,8 @@ import {
   SupportAgent as SupportIcon,
   School as SchoolIcon,
 } from "@mui/icons-material";
-import { ActionItem } from "../types";
 import supportChatService from "@/app/services/support-chat";
 import AdminService from "@/app/services/admin";
-
-interface ActionRequiredProps {
-  actionItems: ActionItem[] | null;
-  loading?: boolean;
-}
 
 interface ActionItemCardProps {
   title: string;
@@ -110,16 +104,47 @@ function ActionItemCard({
   );
 }
 
-export default function ActionRequired({
-  actionItems,
-  loading,
-}: ActionRequiredProps) {
+export default function ActionRequired() {
+  const [pendingReview, setPendingReview] = useState(0);
+  const [reviewLoading, setReviewLoading] = useState(true);
+  const [pendingReports, setPendingReports] = useState(0);
+  const [reportsLoading, setReportsLoading] = useState(true);
   const [pendingQA, setPendingQA] = useState(0);
   const [qaLoading, setQaLoading] = useState(true);
   const [pendingCertification, setPendingCertification] = useState(0);
   const [certificationLoading, setCertificationLoading] = useState(true);
 
   useEffect(() => {
+    const fetchReviewCount = async () => {
+      try {
+        setReviewLoading(true);
+        const response = await AdminService.userReview.getPendingUsers(1, 1);
+        setPendingReview(response.pagination?.total ?? 0);
+      } catch (error) {
+        console.error("회원 심사 대기 건수 조회 실패:", error);
+        setPendingReview(0);
+      } finally {
+        setReviewLoading(false);
+      }
+    };
+
+    const fetchReportsCount = async () => {
+      try {
+        setReportsLoading(true);
+        const params = new URLSearchParams();
+        params.append("page", "1");
+        params.append("limit", "1");
+        params.append("status", "pending");
+        const response = await AdminService.getProfileReports(params);
+        setPendingReports(response.meta?.totalItems ?? 0);
+      } catch (error) {
+        console.error("신고 대기 건수 조회 실패:", error);
+        setPendingReports(0);
+      } finally {
+        setReportsLoading(false);
+      }
+    };
+
     const fetchQACount = async () => {
       try {
         setQaLoading(true);
@@ -140,12 +165,10 @@ export default function ActionRequired({
       try {
         setCertificationLoading(true);
         const response =
-          await AdminService.userAppearance.getUniversityVerificationPendingUsers(
-            {
-              page: 1,
-              limit: 1,
-            },
-          );
+          await AdminService.userAppearance.getUniversityVerificationPending({
+            page: 1,
+            limit: 1,
+          });
         setPendingCertification(
           response.pagination?.total ?? response.total ?? 0,
         );
@@ -157,17 +180,14 @@ export default function ActionRequired({
       }
     };
 
+    fetchReviewCount();
+    fetchReportsCount();
     fetchQACount();
     fetchCertificationCount();
   }, []);
 
-  const pendingApprovals =
-    actionItems?.find((item) => item.type === "pending_approvals")?.count ?? 0;
-  const pendingProfileReports =
-    actionItems?.find((item) => item.type === "pending_reports")?.count ?? 0;
-
   const totalPending =
-    pendingApprovals + pendingProfileReports + pendingQA + pendingCertification;
+    pendingReview + pendingReports + pendingQA + pendingCertification;
 
   return (
     <Card sx={{ mb: 3 }}>
@@ -210,21 +230,21 @@ export default function ActionRequired({
         <Box className="flex gap-3 flex-wrap">
           <ActionItemCard
             title="회원 심사"
-            count={pendingApprovals}
+            count={pendingReview}
             icon={<ProfileReviewIcon fontSize="small" />}
             link="/admin/profile-review"
             color="#3b82f6"
             bgColor="#eff6ff"
-            loading={loading}
+            loading={reviewLoading}
           />
           <ActionItemCard
             title="신고 관리"
-            count={pendingProfileReports}
+            count={pendingReports}
             icon={<ReportIcon fontSize="small" />}
             link="/admin/reports"
             color="#ef4444"
             bgColor="#fef2f2"
-            loading={loading}
+            loading={reportsLoading}
           />
           <ActionItemCard
             title="Q&A 대기"
@@ -239,7 +259,7 @@ export default function ActionRequired({
             title="학생증 인증"
             count={pendingCertification}
             icon={<SchoolIcon fontSize="small" />}
-            link="/admin/users/appearance?tab=6"
+            link="/admin/users/appearance?tab=5"
             color="#f59e0b"
             bgColor="#fffbeb"
             loading={certificationLoading}

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -126,7 +126,7 @@ export default function MainDashboard() {
 					</Alert>
 				)}
 
-				<ActionRequired actionItems={summary?.actionItems ?? null} loading={loading} />
+				<ActionRequired />
 
 				<Grid container spacing={3}>
 					<Grid item xs={12} md={7}>


### PR DESCRIPTION
## Summary
- 대시보드 "긴급 처리 필요" 패널의 4개 항목이 실제 관리 페이지 수치와 불일치하는 버그 수정
- 대시보드 요약 API 의존을 제거하고, 각 관리 페이지와 동일한 API를 직접 호출하도록 변경

## 수정 내역
| 항목 | 원인 | 수정 |
|------|------|------|
| 회원 심사 (389건→0건) | `users.status='PENDING'` 카운트 (계정 승인) vs 실제는 `profile_images.reviewStatus='pending'` (이미지 심사) | `userReview.getPendingUsers()` 사용 |
| 신고 관리 | `profile_reports` 직접 조회 vs 통합 커뮤니티 신고 API | `getProfileReports(status=pending)` 사용 |
| 학생증 인증 (항상 0건) | 존재하지 않는 함수 호출 → silent catch | `getUniversityVerificationPending()` 수정 |
| 학생증 인증 링크 | `?tab=6` (없는 탭) | `?tab=5` 수정 |

## Test plan
- [ ] 대시보드 접속 시 4개 항목 숫자가 각 관리 페이지와 일치하는지 확인
- [ ] 회원 심사 카드 클릭 → /admin/profile-review 이동 확인
- [ ] 신고 관리 카드 클릭 → /admin/reports 이동 확인
- [ ] 학생증 인증 카드 클릭 → /admin/users/appearance?tab=5 이동 확인
- [ ] Q&A 대기 카드 클릭 → /admin/support-chat 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)