### PR TITLE
chore(phase-0): admin hybrid rewrite baseline and freeze

### DIFF
--- a/.eslintrc.admin-v2.json
+++ b/.eslintrc.admin-v2.json
@@ -1,0 +1,34 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "no-console": "error",
+    "no-alert": "error",
+    "no-restricted-globals": [
+      "error",
+      {
+        "name": "localStorage",
+        "message": "Use session hooks from shared/auth instead of localStorage directly."
+      },
+      {
+        "name": "confirm",
+        "message": "Use MUI Dialog instead of window.confirm()."
+      },
+      {
+        "name": "alert",
+        "message": "Use toast/snackbar instead of window.alert()."
+      }
+    ],
+    "no-restricted-properties": [
+      "error",
+      {
+        "object": "window",
+        "property": "location",
+        "message": "Use Next.js router instead of window.location."
+      }
+    ],
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-unused-vars": "error"
+  }
+}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=true

--- a/docs/admin-freeze-policy.md
+++ b/docs/admin-freeze-policy.md
@@ -1,0 +1,39 @@
+# Admin Legacy Code Freeze Policy
+
+**Effective:** Phase 0 start ~ Phase 6 completion
+**Scope:** All files under `app/admin/`, `app/services/admin.ts`, admin-related contexts
+
+## Rules
+
+### Allowed Changes (긴급 수정만)
+
+1. **Production bug fixes** that cause data loss or user-facing errors
+2. **Security patches** for critical vulnerabilities
+3. **Backend API contract changes** that break existing functionality (forced by backend team)
+
+### Forbidden Changes
+
+1. New features in legacy admin pages
+2. Refactoring or "cleanup" of legacy code
+3. Adding new dependencies for legacy pages
+4. Changing admin routing structure outside the rewrite plan
+5. Modifying `app/services/admin.ts` except for bug fixes
+
+### Process for Allowed Changes
+
+1. Describe the issue and why it cannot wait for the rewrite
+2. Make the minimal change needed
+3. Tag the commit with `fix(admin-legacy):` prefix
+4. Document the change in this file's changelog below
+
+### Changelog
+
+| Date | Description | Commit |
+|------|-------------|--------|
+| (template — add entries as needed) | | |
+
+## Rationale
+
+The hybrid rewrite replaces pages one by one under a new Shell. If legacy code keeps changing,
+the rewrite target moves and adapter/bridge assumptions break. Freezing legacy code ensures
+stability during the transition.

--- a/docs/inventories/api-inventory.md
+++ b/docs/inventories/api-inventory.md
@@ -1,0 +1,549 @@
+# Admin API Inventory
+
+**Generated:** 2026-03-12
+**Source file:** `app/services/admin.ts` (4,756 lines)
+**Spec reference:** `docs/superpowers/specs/2026-03-12-admin-hybrid-rewrite-design.md`
+
+---
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Total service methods (async) | 163 |
+| Domain groups (const objects) | 29 |
+| GET endpoints | 85 |
+| POST endpoints | 41 |
+| PUT endpoints | 3 |
+| PATCH endpoints | 9 |
+| DELETE endpoints | 10 |
+| Direct `fetch()` calls (in admin.ts, bypassing axios) | 6 |
+| Direct `axiosServer`/`axiosNextGen` calls in admin pages | 16+ |
+
+## Axios Instance Usage
+
+| Instance | Count | Purpose |
+|----------|-------|---------|
+| `axiosServer` | 159 | JSON API calls, 15s timeout |
+| `axiosMultipart` | 1 | File uploads, 30s timeout |
+| `axiosNextGen` | 17 | Direct next-gen backend calls, 15s timeout |
+| Direct `fetch()` | 6 | Multipart uploads that bypass axios entirely (banners, presets, gems bulk-grant, sometime-articles image, preset upload) |
+
+### Notes on Direct `fetch()` Calls
+These 6 methods in `admin.ts` use the native `fetch()` API instead of any axios instance, typically for multipart form uploads where they need fine-grained control over headers. They must be migrated to `axiosMultipart` or a React Query mutation with proper FormData handling:
+
+| Method | Endpoint |
+|--------|----------|
+| `backgroundPresets.upload` | `POST /admin/background-presets/upload` |
+| `backgroundPresets.uploadAndCreate` | `POST /admin/background-presets/upload-and-create` |
+| `backgroundPresets.uploadSectionImage` | `POST /admin/background-presets/upload` (section variant) |
+| `gems.bulkGrant` | `POST /admin/gems/bulk-grant` |
+| `banners.create` | `POST /admin/banners` |
+| `sometimeArticles.uploadImage` | `POST /admin/sometime-articles/upload` |
+
+---
+
+## Function Inventory
+
+### auth (line 72)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 1 | `auth.cleanup` | — | (localStorage only, no HTTP) | — |
+
+### stats (line 79)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 2 | `getTotalUsersCount` | GET | `/admin/stats/users/total` | axiosServer |
+| 3 | `getDailySignupCount` | GET | `/admin/stats/users/daily` | axiosServer |
+| 4 | `getWeeklySignupCount` | GET | `/admin/stats/users/weekly` | axiosServer |
+| 5 | `getDailySignupTrend` | GET | `/admin/stats/users/trend/daily` | axiosServer |
+| 6 | `getWeeklySignupTrend` | GET | `/admin/stats/users/trend/weekly` | axiosServer |
+| 7 | `getMonthlySignupTrend` | GET | `/admin/stats/users/trend/monthly` | axiosServer |
+| 8 | `getCustomPeriodSignupCount` | POST | `/admin/stats/users/custom-period` | axiosServer |
+| 9 | `getCustomPeriodSignupTrend` | POST | `/admin/stats/users/custom-period` (trend variant) | axiosServer |
+| 10 | `getGenderStats` | GET | `/admin/stats/users/gender` | axiosServer |
+| 11 | `getUniversityStats` | GET | `/admin/stats/users/universities` | axiosServer |
+| 12 | `getTotalWithdrawalsCount` | GET | `/admin/stats/withdrawals/total` | axiosServer |
+| 13 | `getDailyWithdrawalCount` | GET | `/admin/stats/withdrawals/daily` | axiosServer |
+| 14 | `getWeeklyWithdrawalCount` | GET | `/admin/stats/withdrawals/weekly` | axiosServer |
+| 15 | `getMonthlyWithdrawalCount` | GET | `/admin/stats/withdrawals/monthly` | axiosServer |
+| 16 | `getCustomPeriodWithdrawalCount` | POST | `/admin/stats/withdrawals/custom-period` | axiosServer |
+| 17 | `getDailyWithdrawalTrend` | GET | `/admin/stats/withdrawals/trend/daily` | axiosServer |
+| 18 | `getWeeklyWithdrawalTrend` | GET | `/admin/stats/withdrawals/trend/weekly` | axiosServer |
+| 19 | `getMonthlyWithdrawalTrend` | GET | `/admin/stats/withdrawals/trend/monthly` | axiosServer |
+| 20 | `getCustomPeriodWithdrawalTrend` | POST | `/admin/stats/withdrawals/trend/custom-period` | axiosServer |
+| 21 | `getWithdrawalReasonStats` | GET | `/admin/stats/withdrawals/reasons` | axiosServer |
+| 22 | `getChurnRate` | GET | `/admin/stats/withdrawals/churn-rate` | axiosServer |
+
+### userAppearance (line 524)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 23 | `getUsersWithAppearanceGrade` | GET | `/admin/users/appearance` (dynamic URL) | axiosServer |
+| 24 | `getUnclassifiedUsers` | GET | `/admin/users/appearance` (unclassified variant) | axiosServer |
+| 25 | `setUserAppearanceGrade` | PATCH | `/admin/users/appearance/:userId` | axiosServer |
+| 26 | `bulkSetUserAppearanceGrade` | PATCH | `/admin/users/appearance/bulk` | axiosServer |
+| 27 | `getUserDetails` | GET | `/admin/users/:userId/detail` (dynamic) | axiosServer |
+| 28 | `getUserTickets` | GET | `/admin/users/:userId/tickets` (dynamic) | axiosServer |
+| 29 | `createUserTickets` | POST | `/admin/users/:userId/tickets` (dynamic) | axiosServer |
+| 30 | `deleteUserTickets` | DELETE | `/admin/users/:userId/tickets` (dynamic) | axiosServer |
+| 31 | `getUserGems` | GET | `/admin/users/:userId/gems` (dynamic) | axiosServer |
+| 32 | `addUserGems` | POST | `/admin/users/:userId/gems` (dynamic) | axiosServer |
+| 33 | `removeUserGems` | POST | `/admin/users/:userId/gems/remove` (dynamic) | axiosServer |
+| 34 | `updateUserProfile` | POST | `/admin/users/:userId/profile` (dynamic) | axiosServer |
+| 35 | `updateAccountStatus` | POST | `/admin/users/detail/status` | axiosServer |
+| 36 | `sendWarningMessage` | POST | `/admin/users/detail/warning` | axiosServer |
+| 37 | `sendEmailNotification` | POST | `/admin/notification/email` | axiosServer |
+| 38 | `sendSmsNotification` | POST | `/admin/notification/sms` | axiosServer |
+| 39 | `forceLogout` | POST | `/admin/users/detail/logout` | axiosServer |
+| 40 | `sendProfileUpdateRequest` | POST | `/admin/users/detail/profile-update-request` | axiosServer |
+| 41 | `setInstagramError` | POST | `/admin/users/detail/instagram-error` | axiosServer |
+| 42 | `resetInstagramError` | POST | `/admin/users/detail/instagram-reset` | axiosServer |
+| 43 | `getAppearanceGradeStats` | GET | `/admin/users/appearance` (stats variant) | axiosServer |
+| 44 | `deleteUser` | DELETE | `/admin/users/:userId` | axiosServer |
+| 45 | `getDuplicatePhoneUsers` | GET | `/admin/users/duplicate-phone` | axiosServer |
+| 46 | `getVerifiedUsers` | GET | `/admin/users/verified` | axiosServer |
+| 47 | `getUniversityVerificationPending` | GET | `/admin/university-verification` (pending) | axiosServer |
+| 48 | `approveUniversityVerification` | POST | `/admin/university-verification/approve` | axiosServer |
+| 49 | `rejectUniversityVerification` | POST | `/admin/university-verification/reject` | axiosServer |
+| 50 | `getBlacklistUsers` | GET | `/admin/users/blacklist` | axiosServer |
+| 51 | `releaseFromBlacklist` | PATCH | `/admin/users/:userId/blacklist/release` | axiosServer |
+| 52 | `searchUsersForReset` | GET | `/admin/users/search` | axiosServer |
+| 53 | `resetPassword` | PATCH | `/admin/users/:userId/reset-password` | axiosServer |
+| 54 | `getReapplyUsers` | GET | `/admin/users/approval/reapply` | axiosServer |
+| 55 | `getPendingUsers` | GET | `/admin/users/approval/pending` | axiosServer |
+| 56 | `getRejectedUsers` | GET | `/admin/users/approval/rejected` | axiosServer |
+| 57 | `revokeUserApproval` | PATCH | `/admin/users/approval/:userId/revoke-approval` | axiosServer |
+
+### profileImages (line 1701)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 58 | `getPendingProfileImages` | GET | `/admin/profile-images/pending` | axiosServer |
+| 59 | `approveProfileImage` | POST | `/admin/profile-images/users/:userId/approve` | axiosServer |
+| 60 | `rejectProfileImage` | POST | `/admin/profile-images/users/:userId/reject` | axiosServer |
+| 61 | `approveIndividualImage` | POST | `/admin/profile-images/:imageId/approve` | axiosServer |
+| 62 | `rejectIndividualImage` | POST | `/admin/profile-images/:imageId/reject` | axiosServer |
+| 63 | `setMainImage` | POST | `/admin/profile-images/set-main` (dynamic) | axiosServer |
+
+### userReview (line 1878)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 64 | `getPendingUsers` | GET | `/admin/profile-images/pending` | axiosServer |
+| 65 | `getUserDetail` | GET | `/admin/user-review/:userId` | axiosServer |
+| 66 | `approveUser` | POST | `/admin/profile-images/users/:userId/approve` | axiosServer |
+| 67 | `rejectUser` | POST | `/admin/user-review/:userId/reject` | axiosServer |
+| 68 | `bulkRejectUsers` | PATCH | `/admin/user-review/bulk-reject` (dynamic) | axiosServer |
+| 69 | `updateUserRank` | PATCH | `/admin/user-review/:userId/rank` (dynamic) | axiosServer |
+| 70 | `getImageValidation` | GET | `/admin/profile-images/:imageId/validation` | axiosServer |
+| 71 | `getReviewHistory` | GET | `/admin/profile-images/review-history` | axiosServer |
+
+### universities (line 2050)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 72 | `getRegions` (meta) | GET | `/admin/universities/meta/regions` | axiosServer |
+| 73 | `getTypes` (meta) | GET | `/admin/universities/meta/types` | axiosServer |
+| 74 | `getFoundations` (meta) | GET | `/admin/universities/meta/foundations` | axiosServer |
+| 75 | `getList` | GET | `/admin/universities` | axiosServer |
+| 76 | `getById` | GET | `/admin/universities/:id` | axiosServer |
+| 77 | `create` | POST | `/admin/universities` | axiosServer |
+| 78 | `update` | PUT | `/admin/universities/:id` | axiosServer |
+| 79 | `delete` | DELETE | `/admin/universities/:id` | axiosServer |
+| 80 | `uploadLogo` | POST | `/admin/universities/:id/logo` | axiosServer |
+| 81 | `deleteLogo` | DELETE | `/admin/universities/:id/logo` | axiosServer |
+| 82 | `getDepartments` (by univ) | GET | `/admin/universities/:universityId/departments` | axiosServer |
+| 83 | `searchDepartments` | GET | `/admin/universities/departments/search` (dynamic) | axiosServer |
+| 84 | `createDepartment` | POST | `/admin/universities/departments` (dynamic) | axiosServer |
+| 85 | `updateDepartment` | PUT | `/admin/universities/departments/:id` (dynamic) | axiosServer |
+| 86 | `deleteDepartment` | DELETE | `/admin/universities/departments/:id` (dynamic) | axiosServer |
+| 87 | `uploadDepartmentCsv` | POST | `/admin/universities/departments/csv` (dynamic) | axiosServer |
+| 88 | `getClusters` (search) | GET | `/admin/universities/clusters/search` (dynamic) | axiosServer |
+| 89 | `createCluster` | POST | `/admin/universities/clusters` (dynamic) | axiosServer |
+| 90 | `getUniversities` | GET | `/admin/universities` | axiosServer |
+| 91 | `getClusters` | GET | `/admin/universities/clusters` | axiosServer |
+| 92 | `getDepartments` | GET | `/universities/departments` | axiosServer |
+
+### matching (line 2749)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 93 | `getMatchHistory` | GET | `/admin/matching/match-history` | axiosServer |
+| 94 | `getMatchCount` | GET | `/admin/matching/match-count` | axiosServer |
+| 95 | `getUserMatchCount` | GET | `/admin/matching/match-count` (user variant) | axiosServer |
+| 96 | `getMatcherHistory` | GET | `/admin/matching/match-history` (matcher variant) | axiosServer |
+| 97 | `createDirectMatch` | POST | `/admin/matching/direct-match` | axiosServer |
+| 98 | `getFailureLogs` | GET | `/admin/matching/failure-logs` | axiosServer |
+| 99 | `findMatches` | POST | `/admin/matching/user/read` | axiosServer |
+| 100 | `getUnmatchedUsers` | GET | `/admin/matching/unmatched-users` | axiosServer |
+| 101 | `processBatchMatching` | POST | `/admin/matching/batch` | axiosServer |
+| 102 | `processSingleMatching` | POST | `/admin/matching/user` | axiosServer |
+| 103 | `getLikeHistory` | GET | `/admin/matching/like-history` | axiosServer |
+| 104 | `getMatchingStats` | GET | `/admin/matching/stats` (commented out) | axiosServer |
+
+### reports (line 3180)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 105 | `getProfileReports` | GET | `/admin/reports` (dynamic URL) | axiosServer |
+| 106 | `getProfileReportDetail` | GET | `/admin/reports/:reportId` (dynamic) | axiosServer |
+| 107 | `updateReportStatus` | PATCH | `/admin/reports/:reportId/status` (dynamic) | axiosServer |
+| 108 | `getChatHistory` | GET | `/admin/community/chat/:chatRoomId/messages` | axiosServer |
+| 109 | `getUserProfileImages` | GET | `/admin/community/users/:userId/profile-images` | axiosServer |
+
+### pushNotifications (line 3293)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 110 | `filterUsers` | POST | `/admin/push-notifications/filter-users` | axiosServer |
+| 111 | `sendBulkNotification` | POST | `/admin/notifications/bulk` | axiosServer |
+
+### aiChat (line 3340)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 112 | `getSessions` | GET | `/admin/ai-chat/sessions` | axiosServer |
+| 113 | `getMessages` | GET | `/admin/ai-chat/messages?sessionId=:id` | axiosServer |
+
+### backgroundPresets (line 3383)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 114 | `getActive` | GET | `/admin/background-presets/active` | axiosNextGen |
+| 115 | `upload` | POST | `/admin/background-presets/upload` | fetch() |
+| 116 | `uploadAndCreate` | POST | `/admin/background-presets/upload-and-create` | fetch() |
+| 117 | `create` | POST | `/admin/background-presets` | axiosNextGen |
+| 118 | `update` | PUT | `/admin/background-presets/:id` | axiosNextGen |
+| 119 | `delete` | DELETE | `/admin/background-presets/:id` | axiosNextGen |
+| 120 | `uploadSectionImage` | POST | `/admin/background-presets/upload` | fetch() |
+
+### cardNews (line 3538)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 121 | `uploadSectionImage` | POST | (multipart via fetch within backgroundPresets — shared) | — |
+| 122 | `create` | POST | `/admin/posts/card-news` | axiosNextGen |
+| 123 | `get` | GET | `/admin/posts/card-news/:id` | axiosNextGen |
+| 124 | `getList` | GET | `/admin/posts/card-news` | axiosNextGen |
+| 125 | `update` | PUT | `/admin/posts/card-news/:id` | axiosNextGen |
+| 126 | `delete` | DELETE | `/admin/posts/card-news/:id` | axiosNextGen |
+| 127 | `publish` | POST | `/admin/posts/card-news/:id/publish` | axiosNextGen |
+| 128 | `getCategories` | GET | `/articles/category/list` | axiosNextGen |
+
+### femaleRetention (line 3683)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 129 | `getInactiveUsers` | GET | `/admin/female-retention` | axiosServer |
+| 130 | `issueTemporaryPassword` | POST | `/admin/female-retention/:userId` | axiosServer |
+
+### gems (line 3716)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 131 | `bulkGrant` | POST | `/admin/gems/bulk-grant` | fetch() |
+
+### gemPricing (line 3784)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 132 | `getAll` | GET | `/admin/gem-pricing` | axiosServer |
+
+### deletedFemales (line 3791)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 133 | `getList` | GET | `/admin/deleted-females` | axiosServer |
+| 134 | `restore` | PATCH | `/admin/deleted-females/:id/restore` | axiosServer |
+| 135 | `sleep` | PATCH | `/admin/deleted-females/:id/sleep` | axiosServer |
+
+### banners (line 3829)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 136 | `getList` | GET | `/admin/banners` | axiosServer |
+| 137 | `create` | POST | `/admin/banners` | fetch() |
+| 138 | `update` | PATCH | `/admin/banners/:id` | axiosServer |
+| 139 | `delete` | DELETE | `/admin/banners/:id` | axiosServer |
+| 140 | `updateOrder` | PATCH | `/admin/banners/order/bulk` | axiosServer |
+
+### dormantLikes (line 3907)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 141 | `getDashboard` | GET | `/admin/dormant-likes` (dashboard) | axiosServer |
+| 142 | `getPendingLikes` | GET | `/admin/dormant-likes/:userId/pending` | axiosServer |
+| 143 | `getCooldownStatus` | GET | `/admin/dormant-likes/:userId/cooldown` | axiosServer |
+| 144 | `processLikes` | POST | `/admin/dormant-likes/process` | axiosServer |
+| 145 | `getActionLogs` | GET | `/admin/dormant-likes/logs` | axiosServer |
+| 146 | `viewProfile` | POST | `/admin/dormant-likes/view-profile` | axiosServer |
+
+### chatRefund (line 3994)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 147 | `searchUsers` | GET | `/admin/chat-refund/users` (dynamic) | axiosServer |
+| 148 | `getEligibleRooms` | GET | `/admin/chat-refund/:userId/rooms` (dynamic) | axiosServer |
+| 149 | `previewRefund` | POST | `/admin/chat-refund/preview` | axiosServer |
+| 150 | `processRefund` | POST | `/admin/chat-refund/process` | axiosServer |
+
+### appleRefund (line 4063)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 151 | `getList` | GET | `/admin/apple-refund` | axiosServer |
+| 152 | `getDetail` | GET | `/admin/apple-refund/:id` | axiosServer |
+| 153 | `syncRefundStatus` | POST | `/admin/apple-refund/sync` | axiosServer |
+
+### likes (line 4117)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 154 | `getList` | GET | `/admin/likes` | axiosServer |
+
+### sometimeArticles (line 4124)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 155 | `uploadImage` | POST | `/admin/sometime-articles/upload` | fetch() |
+| 156 | `getList` | GET | `/admin/sometime-articles` | axiosNextGen |
+| 157 | `get` | GET | `/admin/sometime-articles/:id` | axiosNextGen |
+| 158 | `create` | POST | `/admin/sometime-articles` | axiosNextGen |
+| 159 | `update` | PATCH | `/admin/sometime-articles/:id` | axiosNextGen |
+| 160 | `delete` | DELETE | `/admin/sometime-articles/:id` | axiosNextGen |
+
+### momentQuestions (line 4260)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 161 | `generate` | POST | `/admin/questions/generate` | axiosServer |
+| 162 | `bulkCreate` | POST | `/admin/questions/bulk` | axiosServer |
+| 163 | `getList` | GET | `/admin/questions` | axiosServer |
+| 164 | `getDetail` | GET | `/admin/questions/:id` | axiosServer |
+| 165 | `update` | PUT | `/admin/questions/:id` | axiosServer |
+| 166 | `delete` | DELETE | `/admin/questions/:id` | axiosServer |
+| 167 | `translate` | POST | `/admin/questions/translate` | axiosServer |
+
+### userEngagement (line 4373)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 168 | `getStats` | GET | `/admin/stats/user-engagement` | axiosServer |
+
+### forceMatching (line 4393)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 169 | `searchUsers` | GET | `/admin/users` | axiosServer |
+| 170 | `createForceChatRoom` | POST | `/admin/force-chat-room` | axiosServer |
+
+### kpiReport (line 4440)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 171 | `getLatest` | GET | `/admin/kpi-report/latest` | axiosServer |
+| 172 | `getByWeek` | GET | `/admin/kpi-report/:year/:week` | axiosServer |
+| 173 | `getDefinitions` | GET | `/admin/kpi-report/definitions` | axiosServer |
+| 174 | `generate` | POST | `/admin/kpi-report/generate` | axiosServer |
+
+### appReviews (line 4551)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 175 | `getList` | GET | `/admin/app-reviews` | axiosServer |
+| 176 | `getStats` | GET | `/admin/app-reviews/stats` | axiosServer |
+| 177 | `toggleFeatured` | PATCH | `/admin/app-reviews/:pk/featured` | axiosServer |
+
+### communityReviewArticles (line 4585)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 178 | `getList` | GET | `/admin/community/articles` | axiosServer |
+| 179 | `toggleFeatured` | PATCH | `/admin/community/articles/:id/featured` | axiosServer |
+
+### publicReviews (line 4641)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 180 | `getList` | GET | `/public-reviews` | axiosServer |
+| 181 | `getFeaturedAppReviews` | GET | `/app-reviews/featured` | axiosServer |
+
+### fcmTokens (line 4713)
+
+| # | Method Name | HTTP | Endpoint | Instance |
+|---|-------------|------|----------|----------|
+| 182 | `getTokens` | GET | `/admin/fcm-tokens` | axiosServer |
+
+---
+
+## Pages Importing from admin.ts
+
+The following 57 files import from `app/services/admin`:
+
+```
+app/admin/ai-chat/page.tsx
+app/admin/app-reviews/components/PublicReviewManagement.tsx
+app/admin/app-reviews/components/ReviewDashboard.tsx
+app/admin/app-reviews/components/ReviewList.tsx
+app/admin/banners/page.tsx
+app/admin/card-news/components/CardEditor.tsx
+app/admin/card-news/components/PresetEditModal.tsx
+app/admin/card-news/components/PresetSelectModal.tsx
+app/admin/card-news/components/PresetUploadModal.tsx
+app/admin/card-news/create/page.tsx
+app/admin/card-news/edit/[id]/page.tsx
+app/admin/card-news/page.tsx
+app/admin/chat/components/ChatManagementTab.tsx
+app/admin/chat/components/ChatRefundTab.tsx
+app/admin/community/page.tsx
+app/admin/dashboard/components/ActionRequired.tsx
+app/admin/dashboard/components/UserEngagementStats.tsx
+app/admin/dashboard/components/WeeklyTrend.tsx
+app/admin/deleted-females/page.tsx
+app/admin/dormant-likes/components/BulkProcessModal.tsx
+app/admin/dormant-likes/components/PendingLikesModal.tsx
+app/admin/dormant-likes/logs/page.tsx
+app/admin/dormant-likes/page.tsx
+app/admin/fcm-tokens/page.tsx
+app/admin/female-retention/page.tsx
+app/admin/gems/page.tsx
+app/admin/gems/pricing/page.tsx
+app/admin/ios-refund/page.tsx
+app/admin/kpi-report/page.tsx
+app/admin/likes/page.tsx
+app/admin/matching-management/components/ForceMatchingTab.tsx
+app/admin/matching-management/components/GemsManagement.tsx
+app/admin/matching-management/components/LikeHistory.tsx
+app/admin/matching-management/components/MatcherHistory.tsx
+app/admin/matching-management/components/SingleMatching.tsx
+app/admin/matching-management/page.tsx
+app/admin/moment/components/QuestionGenerationTab.tsx
+app/admin/moment/components/QuestionListTab.tsx
+app/admin/moment/components/QuestionTranslationTab.tsx
+app/admin/profile-review/components/ImageReviewPanel.tsx
+app/admin/profile-review/components/ReviewHistoryTab.tsx
+app/admin/profile-review/page.tsx
+app/admin/push-notifications/page.tsx
+app/admin/reports/page.tsx
+app/admin/reset-password/page.tsx
+app/admin/sometime-articles/components/ImageUploader.tsx
+app/admin/sometime-articles/components/MarkdownEditor.tsx
+app/admin/sometime-articles/create/page.tsx
+app/admin/sometime-articles/edit/[id]/page.tsx
+app/admin/sometime-articles/page.tsx
+app/admin/universities/clusters/page.tsx
+app/admin/universities/components/DepartmentCsvUpload.tsx
+app/admin/universities/components/DepartmentManagement.tsx
+app/admin/universities/components/LogoUpload.tsx
+app/admin/universities/components/UniversityDetailDialog.tsx
+app/admin/universities/components/UniversityFormDialog.tsx
+app/admin/universities/page.tsx
+app/admin/users/appearance/page.tsx
+```
+
+---
+
+## Direct Axios Calls in Admin Pages (Bypass Service Layer)
+
+These calls use `axiosServer` or `axiosNextGen` directly in admin page/component files, bypassing `app/services/admin.ts`. They must be migrated to React Query hooks during their page's rewrite phase.
+
+### app/admin/matching-management/useBatchStatus.ts
+
+| Line | Method | Endpoint | Notes |
+|------|--------|----------|-------|
+| 18 | GET | `/admin/matching/batch-status` | Custom hook, not in admin.ts |
+| 36 | POST | `/admin/matching/batch-status` | Toggle batch status |
+
+### app/admin/matching-management/components/SingleMatching.tsx
+
+| Line | Method | Endpoint | Notes |
+|------|--------|----------|-------|
+| 282 | GET | `/admin/users/appearance` | Duplicates userAppearance.getUsersWithAppearanceGrade |
+
+### app/admin/matching-management/components/TicketManagement.tsx
+
+| Line | Method | Endpoint | Notes |
+|------|--------|----------|-------|
+| 71 | GET | `/admin/tickets/user/:userId` | Not in admin.ts |
+| 104 | POST | `/admin/tickets` | Not in admin.ts |
+| 150 | DELETE | `/admin/tickets` | Not in admin.ts |
+
+### app/admin/matching-management/page.tsx
+
+| Line | Method | Endpoint | Notes |
+|------|--------|----------|-------|
+| 110 | POST | `/admin/matching/rest-members` | Not in admin.ts |
+| 115 | POST | `/admin/matching/vector` | Not in admin.ts |
+| 376 | GET | `/admin/users/appearance` | Duplicates service layer |
+| 437 | POST | `/admin/matching/user` | Duplicates matching.processSingleMatching |
+| 471 | POST | `/admin/matching/user/read` | Duplicates matching.findMatches |
+| 504 | GET | `/admin/matching/unmatched-users` | Duplicates matching.getUnmatchedUsers |
+| 606 | POST | `/admin/matching/user` | Duplicates matching.processSingleMatching |
+
+### app/admin/lab/components/VisionPhotoTestTab.tsx
+
+| Line | Method | Endpoint | Notes |
+|------|--------|----------|-------|
+| 378 | POST | `/admin/photo-validation/test` | Lab/test endpoint, not in admin.ts |
+
+### app/admin/users/page.tsx
+
+| Line | Method | Endpoint | Notes |
+|------|--------|----------|-------|
+| 127 | GET | `/admin/users` | Duplicates forceMatching.searchUsers |
+
+### app/admin/gems/page.tsx
+
+| Line | Method | Endpoint | Notes |
+|------|--------|----------|-------|
+| 105 | GET | `/admin/users/appearance` | Duplicates service layer |
+
+### app/admin/scheduled-matching/service.ts
+
+This file is a **standalone service module** (not part of admin.ts) with its own axiosServer calls. All endpoints are not in admin.ts and must be migrated to React Query:
+
+| Line | Method | Endpoint | Notes |
+|------|--------|----------|-------|
+| 25 | GET | `/admin/scheduled-matching` | List schedules |
+| 30 | GET | `/admin/scheduled-matching/:country` | Get by country |
+| 37 | POST | `/admin/scheduled-matching` | Create schedule |
+| 45 | PATCH | `/admin/scheduled-matching/:country` | Update schedule |
+| 50 | POST | `/admin/scheduled-matching/trigger` | Manual trigger |
+| 55 | GET | `/admin/scheduled-matching/jobs/status` | All job statuses |
+| 60 | GET | `/admin/scheduled-matching/jobs/status/:country` | Job status by country |
+| 65 | GET | `/admin/scheduled-matching/batches/running` | Running batches |
+| 74 | GET | `/admin/scheduled-matching/batches/:country` | Batches by country |
+| 85 | GET | `/admin/scheduled-matching/batches/detail/:batchId` | Batch detail |
+| 92 | POST | `/admin/scheduled-matching/batches/:batchId/cancel` | Cancel batch |
+| 101 | GET | `/admin/stats/matching-pool` | Matching pool stats |
+| 110 | POST | `/admin/matching/manual` | Manual matching |
+| 115 | POST | `/admin/matching/validate` | Validate match |
+| 122 | GET | `/admin/matching/manual` | Manual matching history |
+
+---
+
+## Endpoints Missing from Service Layer
+
+These endpoints are called directly in admin pages but have no corresponding method in `app/services/admin.ts`:
+
+| Endpoint | HTTP | Found In |
+|----------|------|----------|
+| `/admin/matching/batch-status` | GET/POST | `useBatchStatus.ts` |
+| `/admin/matching/rest-members` | POST | `matching-management/page.tsx` |
+| `/admin/matching/vector` | POST | `matching-management/page.tsx` |
+| `/admin/tickets/user/:userId` | GET | `TicketManagement.tsx` |
+| `/admin/tickets` | POST/DELETE | `TicketManagement.tsx` |
+| `/admin/photo-validation/test` | POST | `VisionPhotoTestTab.tsx` (lab) |
+| `/admin/scheduled-matching/*` | GET/POST/PATCH | `scheduled-matching/service.ts` (15 endpoints) |
+
+---
+
+## Migration Priority Notes
+
+1. **matching-management** pages have the most bypass calls (10+ direct axiosServer calls) — highest migration priority.
+2. `scheduled-matching/service.ts` is a complete standalone service that needs to be merged into `admin.ts` or converted to React Query hooks directly.
+3. The 6 `fetch()` calls in `admin.ts` itself should be converted to `axiosMultipart` for consistency.
+4. `getMatchingStats` (line 3061) has its actual HTTP call commented out — verify if this endpoint is live before migrating.

--- a/docs/inventories/auth-localstorage-inventory.md
+++ b/docs/inventories/auth-localstorage-inventory.md
@@ -1,0 +1,121 @@
+# Admin Auth & localStorage Inventory
+
+**Generated:** 2026-03-12
+**Spec reference:** `docs/superpowers/specs/2026-03-12-admin-hybrid-rewrite-design.md`
+
+---
+
+## localStorage Keys Used by Admin
+
+### Auth Keys (LegacyPageAdapter bridge must sync these)
+
+| Key | Type | Read By | Written By | Bridge Action |
+|-----|------|---------|------------|---------------|
+| `accessToken` | string (JWT) | `utils/axios.ts` (interceptor), `utils/api.ts`, `app/services/admin.ts` (7 call sites), `app/admin/support-chat/hooks/useSupportChatSocket.ts`, `app/admin/dashboard/page.tsx`, `app/admin/dashboard/member-stats/page.tsx`, `app/admin/push-notifications/page.tsx`, `app/admin/kpi-report/page.tsx` | `contexts/AuthContext.tsx` (login), `utils/axios.ts` (token refresh) | Sync from httpOnly cookie on mount; clear on logout |
+| `isAdmin` | `"true"` / `"false"` | `utils/axios.ts` (token refresh), `utils/api.ts`, `app/admin/dashboard/page.tsx`, `app/admin/dashboard/member-stats/page.tsx`, `app/admin/push-notifications/page.tsx`, `app/admin/kpi-report/page.tsx` | `contexts/AuthContext.tsx` (login), `utils/axios.ts` (token refresh) | Sync from session meta cookie on mount; clear on logout |
+| `user` | JSON string (`UserInfo`) | `contexts/AuthContext.tsx` (session restore) | `contexts/AuthContext.tsx` (login) | Sync from session meta cookie on mount; clear on logout |
+| `admin_status` | JSON string `{ verified, timestamp, email }` | _(written only; no reads found outside axios.ts itself)_ | `utils/axios.ts` (token refresh success path) | Sync from session meta on mount; clear on logout |
+| `admin_selected_country` | `"kr"` \| `"jp"` | `contexts/CountryContext.tsx`, `utils/axios.ts` (X-Country header), `utils/api.ts`, `app/services/admin.ts` | `contexts/CountryContext.tsx` (country change) | Sync from cookie bidirectionally; persist country change back to cookie |
+
+### Non-Auth Keys (page-local state, no bridge required)
+
+| Key | Type | Read By | Written By | Bridge Action |
+|-----|------|---------|------------|---------------|
+| `skippedReviewUsers` | JSON array (string[]) | `app/admin/profile-review/page.tsx` | `app/admin/profile-review/page.tsx` | None — page-local UI state |
+| `sms_draft` | JSON string (draft payload) | `app/admin/sms/components/MessageComposer.tsx` | `app/admin/sms/components/MessageComposer.tsx` | None — ephemeral draft, cleared after send |
+
+---
+
+## Scan Coverage
+
+The following paths were scanned for `localStorage.getItem`, `localStorage.setItem`, `localStorage.removeItem`, bracket-notation `localStorage[...]`, and `sessionStorage`:
+
+- `app/admin/**/*.{ts,tsx}`
+- `contexts/**/*.{ts,tsx}`
+- `app/services/**/*.{ts,tsx}`
+- `utils/**/*.{ts,tsx}`
+
+**No sessionStorage usage found.**
+**No bracket-notation `localStorage[key]` usage found.**
+
+The `LocalStorageHelper` class in `app/services/sms.ts` is a generic wrapper used only by `app/admin/sms/components/MessageComposer.tsx` (key: `sms_draft`). It is already captured in the Non-Auth Keys table above.
+
+---
+
+## Auth Flow Analysis
+
+### Current Flow (Legacy)
+
+1. User submits credentials on the login page.
+2. Frontend POSTs to backend `/auth/login` directly via axios.
+3. On success, `contexts/AuthContext.tsx` writes:
+   - `accessToken` — raw JWT string
+   - `user` — JSON-serialised user info object
+   - `isAdmin` — `"true"` or `"false"` string
+4. `utils/axios.ts` interceptor reads `accessToken` from localStorage and injects `Authorization: Bearer <token>` into every request.
+5. `utils/axios.ts` interceptor reads `admin_selected_country` and injects `X-Country` header.
+6. Admin pages (`dashboard`, `kpi-report`, `push-notifications`, etc.) perform their own `localStorage.getItem('accessToken')` / `getItem('isAdmin')` guards before fetching data.
+7. On token expiry (HTTP 401), `utils/axios.ts` auto-refreshes via `/auth/refresh`, then:
+   - Writes new `accessToken` to localStorage.
+   - Writes new `accessToken` to a plain `document.cookie` (not httpOnly).
+   - Conditionally writes `admin_status` JSON to localStorage.
+8. On refresh failure, removes `accessToken`, `isAdmin`, and `admin_status` from localStorage and redirects to `/`.
+9. On explicit logout, `contexts/AuthContext.tsx` removes `accessToken` and `isAdmin`; `app/services/admin.ts` additionally removes `user` and `isAdmin`.
+
+### New Flow (Phase 1+)
+
+1. User submits credentials on the login page.
+2. Frontend POSTs to BFF route `/api/admin/auth/login`.
+3. BFF calls backend `/auth/login`, then stores:
+   - `admin_access_token` in an **httpOnly** cookie (inaccessible to JS).
+   - `admin_session_meta` in an iron-session signed cookie (user info, isAdmin, country).
+4. All admin API calls go through the admin-proxy BFF route; the proxy reads the httpOnly cookie server-side and forwards the `Authorization` header to the backend. No client-side token access.
+5. Next.js middleware checks the iron-session cookie for authentication/authorisation on every request. No localStorage access.
+6. On logout, BFF clears both cookies.
+
+### Bridge Requirements (LegacyPageAdapter)
+
+Legacy pages that have not yet been migrated to the BFF proxy pattern still read auth state directly from localStorage. The `LegacyPageAdapter` must bridge this gap:
+
+| Trigger | Action |
+|---------|--------|
+| Component mount (legacy page load) | Call BFF `/api/admin/auth/session` to get `{ accessToken, user, isAdmin, country }` from session meta; write all five auth keys (`accessToken`, `user`, `isAdmin`, `admin_status`, `admin_selected_country`) to localStorage so legacy code can function. |
+| Country change by user | Update `admin_selected_country` in localStorage (existing CountryContext behaviour); also call BFF to persist country into the iron-session cookie. |
+| Logout | Call BFF `/api/admin/auth/logout` to clear cookies; then `localStorage.removeItem` on `accessToken`, `isAdmin`, `user`, `admin_status`. (`admin_selected_country` and page-local keys are non-auth and may be preserved.) |
+| Token refresh (while legacy) | BFF issues a new httpOnly cookie; LegacyPageAdapter re-syncs `accessToken` to localStorage after refresh completes. |
+
+---
+
+## Files With Auth localStorage Access (complete reference)
+
+| File | Keys Accessed |
+|------|--------------|
+| `contexts/AuthContext.tsx` | `accessToken` (r/w/d), `isAdmin` (w/d), `user` (r/w) |
+| `contexts/CountryContext.tsx` | `admin_selected_country` (r/w) |
+| `utils/axios.ts` | `accessToken` (r/w/d), `admin_selected_country` (r), `isAdmin` (r/w/d), `admin_status` (w/d) |
+| `utils/api.ts` | `accessToken` (r/d), `admin_selected_country` (r), `user` (d), `isAdmin` (d) |
+| `app/services/admin.ts` | `accessToken` (r ×7), `admin_selected_country` (r), `user` (d), `isAdmin` (d) |
+| `app/admin/support-chat/hooks/useSupportChatSocket.ts` | `accessToken` (r) |
+| `app/admin/dashboard/page.tsx` | `accessToken` (r), `isAdmin` (r) |
+| `app/admin/dashboard/member-stats/page.tsx` | `accessToken` (r), `isAdmin` (r) |
+| `app/admin/push-notifications/page.tsx` | `accessToken` (r ×2), `isAdmin` (r) |
+| `app/admin/kpi-report/page.tsx` | `accessToken` (r), `isAdmin` (r) |
+| `app/admin/components/CountrySelectorModal.tsx` | `admin_selected_country` (r — debug logging only; write delegated to CountryContext) |
+| `app/admin/sms/components/MessageComposer.tsx` | `sms_draft` (r/w/d) |
+| `app/admin/profile-review/page.tsx` | `skippedReviewUsers` (r/w/d) |
+
+Legend: r = read, w = write, d = delete/removeItem
+
+---
+
+## Notes & Concerns
+
+1. **`admin_status` is write-only in practice.** It is written during token refresh but never read by any code in the scanned paths. It may be dead code, or it is read by un-scanned paths (e.g. middleware or external scripts). The bridge should sync it defensively.
+
+2. **Direct `accessToken` reads in pages.** Seven pages bypass `AuthContext` and call `localStorage.getItem('accessToken')` directly. These pages need individual attention during Phase 1 migration or must be wrapped by `LegacyPageAdapter` to ensure the token is present in localStorage.
+
+3. **Plain-cookie write during token refresh.** `utils/axios.ts` writes `accessToken` to `document.cookie` (non-httpOnly) as a fallback. This is a security concern and should be removed when the BFF proxy handles token refresh.
+
+4. **`utils/api.ts` is a separate axios factory** from `utils/axios.ts` and manages its own auth removal logic. Both must be updated or retired during Phase 1.
+
+5. **`admin_selected_country` is bidirectional.** Country changes originate client-side and currently never reach the server. The bridge must propagate country changes to the iron-session cookie so the BFF proxy can read them.

--- a/docs/inventories/broken-control-inventory.md
+++ b/docs/inventories/broken-control-inventory.md
@@ -1,0 +1,301 @@
+# Admin Broken-Control Inventory
+
+**Generated:** 2026-03-12
+**Spec reference:** `docs/superpowers/specs/2026-03-12-admin-hybrid-rewrite-design.md`
+
+## Summary
+
+| Pattern | Count | Severity | Resolution |
+|---------|-------|----------|------------|
+| `console.log/warn/error/debug` | 339 | Medium | Remove in page rewrite |
+| `alert()` | 121 | High | Replace with MUI Dialog/toast |
+| `confirm()` | 26 | High | Replace with MUI Dialog |
+| `window.location` (hard nav) | 5 | High | Replace with Next.js router |
+| Direct DOM manipulation | 2 | Medium | Replace with React state/refs |
+| `ignoreBuildErrors: true` | 1 | Critical | Remove in Phase 6 |
+| Middleware auth bypass | 1 | Critical | Rewrite in Phase 1 |
+| `reactStrictMode: false` | 1 | Medium | Enable in Phase 1 |
+| Non-deterministic build ID | 1 | Medium | Fix in Phase 1 |
+
+---
+
+## Global Issues
+
+### middleware.ts (lines 13, 17, 51)
+
+- **Issue:** Multiple `return NextResponse.next()` calls bypass all authentication — any unauthenticated request is passed through
+- **Most critical:** Line 17 is the early-return that skips auth checks for all routes
+- **Impact:** Any user can access `/admin/*` without login
+- **Resolution:** Phase 1 — rewrite with cookie-based JWT validation before routing
+
+### next.config.js
+
+| Line | Issue | Severity | Resolution |
+|------|-------|----------|------------|
+| 57 | `ignoreBuildErrors: true` — TypeScript errors silently pass production builds | Critical | Remove in Phase 6 after type errors are fixed |
+| 71 | `reactStrictMode: false` — disables React double-render and lifecycle checks | Medium | Enable in Phase 1 |
+| 62 | `CACHE_INVALIDATION: Date.now()` as env var — changes every build | Medium | Replace with a stable version/hash |
+| 67 | `generateBuildId: () => \`build-${Date.now()}\`` — non-deterministic, breaks CDN caching | Medium | Use `git rev-parse HEAD` or similar |
+
+---
+
+## Per-File Breakdown
+
+Files are grouped by route. Only files with at least one anti-pattern instance are listed.
+
+### Route: `banners/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `banners/page.tsx` | 3 | 3 | 0 | 0 | 0 |
+| `banners/components/BannerFormDialog.tsx` | 0 | 0 | 0 | 0 | 1 |
+
+### Route: `card-news/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `card-news/page.tsx` | 3 | 6 | 0 | 0 | 0 |
+| `card-news/create/page.tsx` | 5 | 5 | 1 | 0 | 0 |
+| `card-news/edit/[id]/page.tsx` | 5 | 7 | 1 | 0 | 0 |
+| `card-news/components/BackgroundSelector.tsx` | 1 | 4 | 0 | 0 | 0 |
+| `card-news/components/CardEditor.tsx` | 1 | 3 | 0 | 0 | 0 |
+| `card-news/components/PresetEditModal.tsx` | 1 | 0 | 1 | 0 | 0 |
+| `card-news/components/PresetSelectModal.tsx` | 1 | 0 | 0 | 0 | 0 |
+| `card-news/components/PresetUploadModal.tsx` | 1 | 0 | 0 | 0 | 0 |
+
+### Route: `chat/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `chat/components/ChatManagementTab.tsx` | 6 | 0 | 0 | 0 | 0 |
+| `chat/components/ChatRefundTab.tsx` | 4 | 0 | 0 | 0 | 0 |
+| `chat/components/ChatStatsTab.tsx` | 1 | 0 | 0 | 0 | 0 |
+
+### Route: `community/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `community/page.tsx` | 19 | 0 | 1 | 0 | 0 |
+
+### Route: `dashboard/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `dashboard/page.tsx` | 2 | 0 | 0 | 0 | 0 |
+| `dashboard/member-stats/page.tsx` | 1 | 0 | 0 | 0 | 0 |
+| `dashboard/components/ActionRequired.tsx` | 2 | 0 | 0 | 0 | 0 |
+| `dashboard/components/ActionableInsights.tsx` | 1 | 0 | 0 | 0 | 0 |
+| `dashboard/components/GemSystemFunnel.tsx` | 2 | 0 | 0 | 0 | 0 |
+| `dashboard/components/RevenueOverview.tsx` | 1 | 0 | 0 | 0 | 0 |
+| `dashboard/components/UserEngagementStats.tsx` | 1 | 0 | 0 | 0 | 0 |
+| `dashboard/components/WeeklyTrend.tsx` | 1 | 0 | 0 | 0 | 0 |
+
+### Route: `deleted-females/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `deleted-females/page.tsx` | 0 | 4 | 0 | 0 | 0 |
+
+### Route: `dormant-likes/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `dormant-likes/page.tsx` | 0 | 0 | 0 | 0 | 0 |
+| `dormant-likes/components/BulkProcessModal.tsx` | 1 | 0 | 1 | 0 | 0 |
+| `dormant-likes/components/PendingLikesModal.tsx` | 0 | 8 | 2 | 0 | 0 |
+
+### Route: `fcm-tokens/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `fcm-tokens/page.tsx` | 1 | 0 | 0 | 0 | 0 |
+
+### Route: `female-retention/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `female-retention/page.tsx` | 2 | 3 | 0 | 0 | 0 |
+
+### Route: `gems/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `gems/page.tsx` | 2 | 12 | 0 | 0 | 0 |
+
+### Route: `ios-refund/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `ios-refund/page.tsx` | 2 | 2 | 0 | 0 | 0 |
+
+### Route: `kpi-report/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `kpi-report/page.tsx` | 4 | 0 | 0 | 0 | 0 |
+
+### Route: `lab/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `lab/components/VisionPhotoTestTab.tsx` | 1 | 0 | 0 | 0 | 1 |
+
+### Route: `layout.tsx` (shared)
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `layout.tsx` | 9 | 0 | 0 | 0 | 0 |
+
+### Route: `matching-management/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `matching-management/page.tsx` | 18 | 0 | 0 | 0 | 0 |
+| `matching-management/useBatchStatus.ts` | 2 | 0 | 0 | 0 | 0 |
+| `matching-management/components/ForceMatchingTab.tsx` | 2 | 0 | 0 | 0 | 0 |
+| `matching-management/components/GemsManagement.tsx` | 6 | 0 | 0 | 0 | 0 |
+| `matching-management/components/LikeHistory.tsx` | 3 | 0 | 0 | 0 | 0 |
+| `matching-management/components/MatcherHistory.tsx` | 2 | 0 | 0 | 0 | 0 |
+| `matching-management/components/SingleMatching.tsx` | 8 | 0 | 0 | 0 | 0 |
+| `matching-management/components/TicketManagement.tsx` | 6 | 0 | 0 | 0 | 0 |
+
+### Route: `profile-review/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `profile-review/page.tsx` | 13 | 0 | 0 | 0 | 0 |
+| `profile-review/components/ImageReviewPanel.tsx` | 3 | 6 | 2 | 0 | 0 |
+| `profile-review/components/ReviewHistoryTab.tsx` | 2 | 0 | 0 | 0 | 0 |
+| `profile-review/components/RejectReasonModal.tsx` | 0 | 2 | 0 | 0 | 0 |
+
+### Route: `push-notifications/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `push-notifications/page.tsx` | 9 | 12 | 3 | 3 | 0 |
+
+### Route: `reports/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `reports/page.tsx` | 6 | 4 | 0 | 0 | 0 |
+
+### Route: `reset-password/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `reset-password/page.tsx` | 0 | 2 | 0 | 0 | 0 |
+
+### Route: `sales/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `sales/components/DailySalesTrendGraph.tsx` | 1 | 0 | 0 | 0 | 0 |
+| `sales/components/InsightsTab.tsx` | 6 | 0 | 0 | 0 | 0 |
+| `sales/components/MonthlyPaymentGraph.tsx` | 2 | 0 | 0 | 0 | 0 |
+| `sales/components/PaymentAnalysis.tsx` | 2 | 0 | 0 | 0 | 0 |
+| `sales/components/PeriodSalesSummary.tsx` | 1 | 0 | 0 | 0 | 0 |
+| `sales/components/PeriodSelector.tsx` | 4 | 0 | 0 | 0 | 0 |
+| `sales/components/ProductAnalysisTab.tsx` | 5 | 0 | 0 | 0 | 0 |
+| `sales/components/RankingByUniv.tsx` | 3 | 0 | 0 | 0 | 0 |
+| `sales/components/RevenueMetricsTab.tsx` | 7 | 0 | 0 | 0 | 0 |
+| `sales/components/SalesGrowthAnalysis.tsx` | 1 | 0 | 0 | 0 | 0 |
+| `sales/components/SuccessRate.tsx` | 1 | 0 | 0 | 0 | 0 |
+| `sales/components/TotalAmount.tsx` | 13 | 0 | 0 | 0 | 0 |
+
+### Route: `scheduled-matching/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `scheduled-matching/components/BatchDetailModal.tsx` | 1 | 0 | 0 | 0 | 0 |
+| `scheduled-matching/components/BatchHistory.tsx` | 1 | 0 | 0 | 0 | 0 |
+| `scheduled-matching/components/CountryOverview.tsx` | 5 | 0 | 1 | 0 | 0 |
+| `scheduled-matching/components/ManualMatching.tsx` | 5 | 0 | 1 | 0 | 0 |
+| `scheduled-matching/components/ScheduleConfig.tsx` | 2 | 0 | 0 | 0 | 0 |
+
+### Route: `sms/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `sms/components/MessageComposer.tsx` | 30 | 17 | 4 | 0 | 0 |
+| `sms/components/RecipientSelector.tsx` | 10 | 0 | 0 | 0 | 0 |
+| `sms/components/SmsHistoryTable.tsx` | 1 | 0 | 0 | 0 | 0 |
+| `sms/components/TemplateManager.tsx` | 3 | 5 | 1 | 0 | 0 |
+
+### Route: `sometime-articles/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `sometime-articles/page.tsx` | 3 | 3 | 1 | 0 | 0 |
+| `sometime-articles/create/page.tsx` | 1 | 1 | 1 | 0 | 0 |
+| `sometime-articles/edit/[id]/page.tsx` | 2 | 1 | 1 | 0 | 0 |
+| `sometime-articles/components/ImageUploader.tsx` | 1 | 0 | 0 | 0 | 0 |
+| `sometime-articles/components/MarkdownEditor.tsx` | 1 | 3 | 0 | 0 | 0 |
+
+### Route: `support-chat/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `support-chat/components/ChatDetailDialog.tsx` | 4 | 0 | 0 | 0 | 0 |
+| `support-chat/components/ChatPanel.tsx` | 4 | 0 | 0 | 0 | 0 |
+| `support-chat/components/SessionListTab.tsx` | 1 | 0 | 0 | 0 | 0 |
+| `support-chat/hooks/useSessionPolling.ts` | 2 | 0 | 0 | 0 | 0 |
+| `support-chat/hooks/useSupportChatSocket.ts` | 10 | 0 | 0 | 0 | 0 |
+
+### Route: `universities/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `universities/page.tsx` | 1 | 2 | 1 | 0 | 0 |
+| `universities/components/DepartmentManagement.tsx` | 1 | 3 | 1 | 0 | 0 |
+| `universities/components/UniversityDetailDialog.tsx` | 1 | 0 | 0 | 0 | 0 |
+| `universities/components/UniversityFormDialog.tsx` | 1 | 2 | 0 | 0 | 0 |
+| `universities/components/DepartmentCsvUpload.tsx` | 0 | 0 | 1 | 0 | 0 |
+| `universities/components/LogoUpload.tsx` | 0 | 0 | 1 | 0 | 0 |
+
+### Route: `users/`
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `users/page.tsx` | 21 | 1 | 0 | 1 | 0 |
+| `users/appearance/page.tsx` | 11 | 0 | 0 | 0 | 0 |
+
+### Shared Components
+
+| File | console | alert | confirm | window.location | DOM |
+|------|---------|-------|---------|-----------------|-----|
+| `components/CountrySelectorModal.tsx` | 4 | 0 | 0 | 1 | 0 |
+
+---
+
+## High-Priority Files (Most Anti-Patterns)
+
+Files with the most accumulated debt, highest priority for rewrite:
+
+| File | Total Issues | Breakdown |
+|------|-------------|-----------|
+| `sms/components/MessageComposer.tsx` | 51 | 30 console + 17 alert + 4 confirm |
+| `community/page.tsx` | 20 | 19 console + 1 confirm |
+| `matching-management/page.tsx` | 18 | 18 console |
+| `push-notifications/page.tsx` | 27 | 9 console + 12 alert + 3 confirm + 3 window.location |
+| `users/page.tsx` | 23 | 21 console + 1 alert + 1 window.location |
+| `gems/page.tsx` | 14 | 2 console + 12 alert |
+| `sales/components/TotalAmount.tsx` | 13 | 13 console |
+| `profile-review/page.tsx` | 13 | 13 console |
+
+---
+
+## Resolution Mapping
+
+| Severity | Pattern | Target API |
+|----------|---------|-----------|
+| Critical | Middleware bypass | Cookie-based JWT check in middleware.ts |
+| Critical | `ignoreBuildErrors: true` | Remove flag; fix all TS errors first |
+| High | `alert()` | MUI `Snackbar`/`Alert` or `Dialog` |
+| High | `confirm()` | MUI `Dialog` with confirm/cancel buttons |
+| High | `window.location.href` | `useRouter().push()` from `next/navigation` |
+| Medium | `window.location.reload()` | `router.refresh()` from `next/navigation` |
+| Medium | `console.*` | Remove or replace with structured logger |
+| Medium | DOM manipulation | React `ref` or state-driven rendering |
+| Medium | `reactStrictMode: false` | Set to `true` in next.config.js |
+| Medium | Non-deterministic build ID | Use `git rev-parse --short HEAD` |

--- a/docs/inventories/route-inventory.md
+++ b/docs/inventories/route-inventory.md
@@ -1,0 +1,69 @@
+# Admin Route Inventory
+
+**Generated:** 2026-03-12
+**Total routes:** 31
+**Spec reference:** `docs/superpowers/specs/2026-03-12-admin-hybrid-rewrite-design.md`
+
+## Summary by Phase
+
+| Phase | Routes | Count |
+|-------|--------|-------|
+| Phase 2 | dashboard, kpi-report | 2 |
+| Phase 3A | users, profile-review, push-notifications | 3 |
+| Phase 3B | matching-management | 1 |
+| Phase 4 | reports, sms, support-chat, community | 4 |
+| Phase 5 | ai-chat, app-reviews, banners, card-news, chat, deleted-females, dormant-likes, fcm-tokens, female-retention, force-matching, gems, ios-refund, lab, likes, moment, reset-password, sales, scheduled-matching, sometime-articles, universities, version-management | 21 |
+| **Total** | | **31** |
+
+## Detailed Inventory
+
+| # | Route | File Path | Phase | 'use client' | Files Count | Patterns (axios/localStorage/alert) | Notes |
+|---|-------|-----------|-------|--------------|-------------|--------------------------------------|-------|
+| 1 | ai-chat | app/admin/ai-chat/page.tsx | 5 | Yes | 3 | 0/0/0 | |
+| 2 | app-reviews | app/admin/app-reviews/page.tsx | 5 | Yes | 4 | 0/0/0 | |
+| 3 | banners | app/admin/banners/page.tsx | 5 | Yes | 3 | 0/0/1 | alert usage |
+| 4 | card-news | app/admin/card-news/page.tsx | 5 | Yes | 10 | 0/0/6 | heavy alert usage |
+| 5 | chat | app/admin/chat/page.tsx | 5 | Yes | 4 | 0/0/0 | |
+| 6 | community | app/admin/community/page.tsx | 4 | Yes | 1 | 0/0/1 | alert usage |
+| 7 | dashboard | app/admin/dashboard/page.tsx | 2 | Yes | 11 | 0/2/1 | localStorage + alert |
+| 8 | deleted-females | app/admin/deleted-females/page.tsx | 5 | Yes | 1 | 0/0/1 | alert usage |
+| 9 | dormant-likes | app/admin/dormant-likes/page.tsx | 5 | Yes | 4 | 0/0/2 | alert usage |
+| 10 | fcm-tokens | app/admin/fcm-tokens/page.tsx | 5 | Yes | 1 | 0/0/0 | |
+| 11 | female-retention | app/admin/female-retention/page.tsx | 5 | Yes | 1 | 0/0/1 | alert usage |
+| 12 | force-matching | app/admin/force-matching/page.tsx | 5 | Yes | 1 | 0/0/0 | |
+| 13 | gems | app/admin/gems/page.tsx | 5 | Yes | 2 | 1/0/1 | axios + alert |
+| 14 | ios-refund | app/admin/ios-refund/page.tsx | 5 | Yes | 1 | 0/0/1 | alert usage |
+| 15 | kpi-report | app/admin/kpi-report/page.tsx | 2 | Yes | 8 | 0/1/0 | localStorage usage |
+| 16 | lab | app/admin/lab/page.tsx | 5 | Yes | 2 | 1/0/0 | axios usage |
+| 17 | likes | app/admin/likes/page.tsx | 5 | Yes | 1 | 0/0/0 | |
+| 18 | matching-management | app/admin/matching-management/page.tsx | 3B | Yes | 12 | 4/0/0 | heavy axios usage |
+| 19 | moment | app/admin/moment/page.tsx | 5 | Yes | 6 | 0/0/0 | |
+| 20 | profile-review | app/admin/profile-review/page.tsx | 3A | No | 6 | 1/1/2 | no 'use client'; axios + localStorage + alert |
+| 21 | push-notifications | app/admin/push-notifications/page.tsx | 3A | Yes | 1 | 0/1/1 | localStorage + alert |
+| 22 | reports | app/admin/reports/page.tsx | 4 | No | 1 | 0/0/1 | no 'use client'; alert usage |
+| 23 | reset-password | app/admin/reset-password/page.tsx | 5 | Yes | 1 | 0/0/1 | alert usage |
+| 24 | sales | app/admin/sales/page.tsx | 5 | No | 19 | 0/0/0 | no 'use client'; largest dir (19 files) |
+| 25 | scheduled-matching | app/admin/scheduled-matching/page.tsx | 5 | Yes | 14 | 1/0/2 | axios + alert |
+| 26 | sms | app/admin/sms/page.tsx | 4 | Yes | 7 | 0/1/2 | localStorage + alert |
+| 27 | sometime-articles | app/admin/sometime-articles/page.tsx | 5 | Yes | 5 | 0/0/4 | heavy alert usage |
+| 28 | support-chat | app/admin/support-chat/page.tsx | 4 | Yes | 8 | 0/1/1 | localStorage + alert |
+| 29 | universities | app/admin/universities/page.tsx | 5 | Yes | 11 | 0/0/5 | heavy alert usage |
+| 30 | users | app/admin/users/page.tsx | 3A | Yes | 3 | 1/0/1 | axios + alert |
+| 31 | version-management | app/admin/version-management/page.tsx | 5 | Yes | 1 | 0/0/0 | |
+
+## Pattern Summary
+
+| Pattern | Routes Affected | Count |
+|---------|----------------|-------|
+| Direct axios usage | matching-management, gems, lab, scheduled-matching, profile-review, users | 6 |
+| localStorage usage | dashboard, kpi-report, profile-review, push-notifications, sms, support-chat | 6 |
+| alert/confirm usage | banners, card-news, community, dashboard, deleted-females, dormant-likes, female-retention, gems, ios-refund, profile-review, push-notifications, reports, reset-password, scheduled-matching, sms, sometime-articles, support-chat, universities, users | 19 |
+| Missing 'use client' | profile-review, reports, sales | 3 |
+
+## Notes
+
+- **profile-review** is the only Phase 3A route missing `'use client'` — needs attention during rewrite.
+- **reports** (Phase 4) is missing `'use client'` — server component or omission to verify.
+- **sales** (Phase 5) has no `'use client'` and is the largest directory at 19 files.
+- **matching-management** (Phase 3B) has the most direct axios calls (4 files) — highest migration effort.
+- **alert/confirm** is used in 19 of 31 routes (61%) — broad impact for replacement with modal dialogs.

--- a/docs/phase-0-completion.md
+++ b/docs/phase-0-completion.md
@@ -1,0 +1,31 @@
+# Phase 0: Baseline and Freeze — Completion Checklist
+
+## Deliverables
+
+- [x] `.npmrc` with `shamefully-hoist=true`
+- [x] `pnpm install` works cleanly
+- [x] `pnpm build` completes
+- [x] `preinstall` script enforces pnpm-only
+- [x] `docs/vercel-pnpm-setup.md` — Vercel configuration documented
+- [x] `docs/admin-freeze-policy.md` — freeze rules documented
+- [x] `docs/inventories/route-inventory.md` — 31 routes cataloged
+- [x] `docs/inventories/api-inventory.md` — admin.ts functions cataloged
+- [x] `docs/inventories/broken-control-inventory.md` — anti-patterns cataloged
+- [x] `docs/inventories/auth-localstorage-inventory.md` — auth keys mapped
+- [x] `tsconfig.admin-v2.json` — scoped strict TypeScript
+- [x] `.eslintrc.admin-v2.json` — scoped strict ESLint
+- [x] `pnpm typecheck:admin-v2` passes
+- [x] `pnpm lint:admin-v2` passes
+- [x] `pnpm quality:admin-v2` passes
+- [x] All commits pushed to branch
+
+## Quality Gate Status
+
+```bash
+pnpm quality:admin-v2  # Must exit 0
+```
+
+## Ready for Phase 1?
+
+Phase 1 can begin when ALL items above are checked.
+Phase 1 scope: AdminShell, BFF routes, middleware rewrite, LegacyPageAdapter.

--- a/docs/superpowers/plans/2026-03-12-phase-0-baseline-and-freeze.md
+++ b/docs/superpowers/plans/2026-03-12-phase-0-baseline-and-freeze.md
@@ -1,0 +1,814 @@
+# Phase 0: Baseline and Freeze — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish the project baseline — lock down legacy code, create comprehensive inventories of every admin page/API/broken pattern/auth dependency, set up scoped quality gates for new code, and finalize pnpm as the sole package manager.
+
+**Architecture:** Phase 0 is configuration + documentation only. No runtime code changes. We create 4 inventory documents, 1 freeze policy, scoped TypeScript/ESLint configs for future new code, and finalize pnpm setup. All outputs live in `docs/` and project root config files.
+
+**Tech Stack:** pnpm, TypeScript 4.9.5 (existing), ESLint (existing next config), shell scripts for inventory generation
+
+---
+
+## Chunk 1: pnpm Finalization and Freeze Policy
+
+### Task 1: Finalize pnpm as sole package manager
+
+**Files:**
+- Create: `.npmrc`
+- Verify: `pnpm-lock.yaml` (already exists)
+- Verify: no `package-lock.json` (already removed)
+
+**Context:** `pnpm-lock.yaml` already exists and `package-lock.json` is already removed. We need `.npmrc` with hoisting config for MUI/Emotion compatibility, and verification that everything resolves.
+
+- [ ] **Step 1: Create `.npmrc` with shamefully-hoist**
+
+```ini
+shamefully-hoist=true
+```
+
+Why: MUI and Emotion packages require hoisting to work correctly with pnpm's strict node_modules structure.
+
+- [ ] **Step 2: Verify pnpm install works cleanly**
+
+Run: `pnpm install`
+Expected: All dependencies resolve without errors. `node_modules` populated correctly.
+
+- [ ] **Step 3: Verify dev server starts**
+
+Run: `pnpm dev`
+Expected: Dev server starts on port 3001 without module resolution errors. Kill after confirming startup.
+
+- [ ] **Step 4: Verify build completes**
+
+Run: `pnpm build`
+Expected: Build completes (with existing type errors tolerated via `ignoreBuildErrors: true`).
+
+- [ ] **Step 5: Add pnpm-only enforcement to package.json**
+
+Modify: `package.json`
+
+Add to the `scripts` section:
+```json
+"preinstall": "npx only-allow pnpm"
+```
+
+This prevents accidental `npm install` or `yarn install` from corrupting the lockfile.
+
+Note: `npx only-allow pnpm` downloads the `only-allow` package on first run. An alternative is adding `"packageManager": "pnpm@9.x.x"` to `package.json` and enabling corepack (`corepack enable`), which is the modern Node.js standard. Both approaches work — `only-allow` is simpler to set up, corepack is more robust.
+
+- [ ] **Step 6: Document Vercel build settings**
+
+Create: `docs/vercel-pnpm-setup.md`
+
+```markdown
+# Vercel pnpm Build Settings
+
+## Required Vercel Project Settings
+
+| Setting | Value |
+|---------|-------|
+| Framework Preset | Next.js |
+| Build Command | `pnpm build` |
+| Install Command | `pnpm install` |
+| Node.js Version | 18.x |
+
+## Notes
+
+- `.npmrc` with `shamefully-hoist=true` is required for MUI/Emotion compatibility.
+- `package-lock.json` has been removed. Only `pnpm-lock.yaml` is used.
+- `preinstall` script enforces pnpm-only via `only-allow`.
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .npmrc package.json pnpm-lock.yaml docs/vercel-pnpm-setup.md
+git commit -m "chore(phase-0): finalize pnpm as sole package manager
+
+- Add .npmrc with shamefully-hoist=true for MUI/Emotion compat
+- Add preinstall script to enforce pnpm-only
+- Document Vercel build settings for pnpm"
+```
+
+---
+
+### Task 2: Document freeze policy for legacy admin code
+
+**Files:**
+- Create: `docs/admin-freeze-policy.md`
+
+**Context:** During the hybrid rewrite, legacy admin code must be frozen except for critical production fixes. This prevents the rewrite target from moving while we work.
+
+- [ ] **Step 1: Create freeze policy document**
+
+Create: `docs/admin-freeze-policy.md`
+
+```markdown
+# Admin Legacy Code Freeze Policy
+
+**Effective:** Phase 0 start ~ Phase 6 completion
+**Scope:** All files under `app/admin/`, `app/services/admin.ts`, admin-related contexts
+
+## Rules
+
+### Allowed Changes (긴급 수정만)
+
+1. **Production bug fixes** that cause data loss or user-facing errors
+2. **Security patches** for critical vulnerabilities
+3. **Backend API contract changes** that break existing functionality (forced by backend team)
+
+### Forbidden Changes
+
+1. New features in legacy admin pages
+2. Refactoring or "cleanup" of legacy code
+3. Adding new dependencies for legacy pages
+4. Changing admin routing structure outside the rewrite plan
+5. Modifying `app/services/admin.ts` except for bug fixes
+
+### Process for Allowed Changes
+
+1. Describe the issue and why it cannot wait for the rewrite
+2. Make the minimal change needed
+3. Tag the commit with `fix(admin-legacy):` prefix
+4. Document the change in this file's changelog below
+
+### Changelog
+
+| Date | Description | Commit |
+|------|-------------|--------|
+| (template — add entries as needed) | | |
+
+## Rationale
+
+The hybrid rewrite replaces pages one by one under a new Shell. If legacy code keeps changing,
+the rewrite target moves and adapter/bridge assumptions break. Freezing legacy code ensures
+stability during the transition.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/admin-freeze-policy.md
+git commit -m "docs(phase-0): add admin legacy code freeze policy
+
+Defines what changes are allowed during the hybrid rewrite period.
+Only critical production fixes permitted in legacy admin code."
+```
+
+---
+
+## Chunk 2: Route Inventory and API Inventory
+
+### Task 3: Create route inventory
+
+**Files:**
+- Create: `docs/inventories/route-inventory.md`
+
+**Context:** We have 31 admin page directories confirmed via `app/admin/*/page.tsx`. Each needs to be cataloged with its current state, phase assignment, and key characteristics.
+
+- [ ] **Step 0: Create inventories directory**
+
+Run: `mkdir -p docs/inventories`
+
+- [ ] **Step 1: Scan all admin routes and create inventory**
+
+For each of the 31 admin routes, record:
+- Route path
+- File path
+- `'use client'` status
+- Assigned phase (from design spec)
+- Component count (files in that directory)
+- Key dependencies (charts, tables, modals, etc.)
+
+Create: `docs/inventories/route-inventory.md`
+
+```markdown
+# Admin Route Inventory
+
+**Generated:** 2026-03-12
+**Total routes:** 31
+**Spec reference:** `docs/superpowers/specs/2026-03-12-admin-hybrid-rewrite-design.md`
+
+## Summary by Phase
+
+| Phase | Routes | Count |
+|-------|--------|-------|
+| Phase 2 | dashboard, kpi-report | 2 |
+| Phase 3A | users, profile-review, push-notifications | 3 |
+| Phase 3B | matching-management | 1 |
+| Phase 4 | reports, sms, support-chat, community | 4 |
+| Phase 5 | (remaining) | 21 |
+| **Total** | | **31** |
+
+## Detailed Inventory
+
+| # | Route | File Path | Phase | 'use client' | Sub-components | Notes |
+|---|-------|-----------|-------|---------------|----------------|-------|
+```
+
+Populate all 31 rows using this script to generate the raw data:
+
+```bash
+# Generate route inventory data
+for dir in app/admin/*/; do
+  route=$(basename "$dir")
+  page="$dir/page.tsx"
+  if [ -f "$page" ]; then
+    use_client=$(grep -l "'use client'" "$page" 2>/dev/null && echo "Yes" || echo "No")
+    file_count=$(find "$dir" -name "*.tsx" -o -name "*.ts" | wc -l | tr -d ' ')
+    has_axios=$(grep -rl "axios" "$dir" --include="*.ts" --include="*.tsx" 2>/dev/null | wc -l | tr -d ' ')
+    has_localstorage=$(grep -rl "localStorage" "$dir" --include="*.ts" --include="*.tsx" 2>/dev/null | wc -l | tr -d ' ')
+    has_alert=$(grep -rl "alert\|confirm(" "$dir" --include="*.ts" --include="*.tsx" 2>/dev/null | wc -l | tr -d ' ')
+    echo "| $route | $page | $use_client | $file_count files | axios:$has_axios ls:$has_localstorage alert:$has_alert |"
+  fi
+done
+```
+
+Then manually add the Phase assignment column based on the spec (Phase 2/3A/3B/4/5).
+
+- [ ] **Step 2: Verify inventory completeness**
+
+Run: `ls -d app/admin/*/page.tsx | wc -l`
+Expected: `31` — must match the inventory row count.
+
+Run: Cross-check every directory in `app/admin/` against the inventory. No route should be missing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/inventories/route-inventory.md
+git commit -m "docs(phase-0): create admin route inventory (31 pages)
+
+Catalogs all admin routes with phase assignments, client component
+status, sub-component counts, and key patterns."
+```
+
+---
+
+### Task 4: Create API inventory
+
+**Files:**
+- Create: `docs/inventories/api-inventory.md`
+- Read: `app/services/admin.ts` (4,756 lines — the source of truth)
+
+**Context:** `app/services/admin.ts` is a 4,756-line monolith containing all admin API calls. We need to catalog every exported function, the backend endpoint it calls, which pages use it, and which HTTP method/axios instance it uses.
+
+- [ ] **Step 1: Extract all exported functions from admin.ts**
+
+Run these commands to generate the raw data:
+
+```bash
+# List all exported functions with line numbers
+grep -n "^export " app/services/admin.ts
+
+# Count by HTTP method
+echo "GET:"; grep -c "\.get(" app/services/admin.ts
+echo "POST:"; grep -c "\.post(" app/services/admin.ts
+echo "PUT:"; grep -c "\.put(" app/services/admin.ts
+echo "PATCH:"; grep -c "\.patch(" app/services/admin.ts
+echo "DELETE:"; grep -c "\.delete(" app/services/admin.ts
+
+# Count by axios instance
+echo "axiosServer:"; grep -c "axiosServer" app/services/admin.ts
+echo "axiosMultipart:"; grep -c "axiosMultipart" app/services/admin.ts
+echo "axiosNextGen:"; grep -c "axiosNextGen" app/services/admin.ts
+
+# Find which pages import from admin.ts
+grep -rn "from.*services/admin" app/admin/ --include="*.ts" --include="*.tsx" | cut -d: -f1 | sort -u
+```
+
+For each exported function, record:
+- Function name
+- HTTP method (GET/POST/PUT/PATCH/DELETE)
+- Backend endpoint path
+- Axios instance used (`axiosServer`, `axiosMultipart`, `axiosNextGen`, or direct `axios`)
+- Which admin page(s) import and call it
+
+- [ ] **Step 2: Create API inventory document**
+
+Create: `docs/inventories/api-inventory.md`
+
+```markdown
+# Admin API Inventory
+
+**Generated:** 2026-03-12
+**Source file:** `app/services/admin.ts` (4,756 lines)
+**Spec reference:** `docs/superpowers/specs/2026-03-12-admin-hybrid-rewrite-design.md`
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Total exported functions | (scan result) |
+| GET endpoints | (scan result) |
+| POST endpoints | (scan result) |
+| PUT/PATCH endpoints | (scan result) |
+| DELETE endpoints | (scan result) |
+| Direct axios calls (not via service) | 44+ (in admin pages) |
+
+## Axios Instance Usage
+
+| Instance | Count | Purpose |
+|----------|-------|---------|
+| `axiosServer` | (scan) | JSON API calls, 15s timeout |
+| `axiosMultipart` | (scan) | File uploads, 30s timeout |
+| `axiosNextGen` | (scan) | Direct backend calls, 15s timeout |
+| Direct `axios` | (scan) | Unmanaged calls (to be eliminated) |
+
+## Function Inventory
+
+| # | Function Name | Method | Endpoint | Axios Instance | Used By (Pages) |
+|---|---------------|--------|----------|----------------|-----------------|
+```
+
+Populate all rows from the scan. Group by domain (dashboard, users, matching, etc.) for readability.
+
+- [ ] **Step 3: Catalog direct axios calls in admin pages**
+
+These are calls that bypass `admin.ts` and call axios directly from page/component files. Already identified 44+ occurrences across 8 files. List each one with file path and line number.
+
+Add a section to the inventory:
+
+```markdown
+## Direct Axios Calls (Bypass Service Layer)
+
+These calls do NOT go through `app/services/admin.ts` and must be migrated
+to React Query hooks during their page's rewrite phase.
+
+| File | Line | Method | Endpoint | Notes |
+|------|------|--------|----------|-------|
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/inventories/api-inventory.md
+git commit -m "docs(phase-0): create admin API inventory
+
+Catalogs all exported functions in admin.ts (4,756 lines),
+their endpoints, axios instances, and consuming pages.
+Also lists 44+ direct axios calls that bypass the service layer."
+```
+
+---
+
+## Chunk 3: Broken-Control Inventory and Auth/localStorage Inventory
+
+### Task 5: Create broken-control inventory
+
+**Files:**
+- Create: `docs/inventories/broken-control-inventory.md`
+
+**Context:** The admin codebase has numerous anti-patterns that must be tracked for systematic elimination during rewrites. Key categories: `console.log/warn/error` (59+ in admin), `alert()/confirm()` (47+ occurrences), `window.location` usage, bypassed middleware, and `ignoreBuildErrors`.
+
+- [ ] **Step 1: Scan for all broken control patterns**
+
+Run these scans and record results:
+
+```bash
+# console usage (per-file counts)
+grep -rcn "console\.\(log\|warn\|error\|debug\)" app/admin/ --include="*.ts" --include="*.tsx"
+
+# alert/confirm (word-boundary to avoid false positives like alertMessage)
+grep -rn "\balert\s*(" app/admin/ --include="*.ts" --include="*.tsx"
+grep -rn "\bconfirm\s*(" app/admin/ --include="*.ts" --include="*.tsx"
+
+# window.location (hard navigation instead of Next.js router)
+grep -rn "window\.location" app/admin/ --include="*.ts" --include="*.tsx"
+
+# Direct DOM manipulation
+grep -rn "document\.\(getElementById\|querySelector\)" app/admin/ --include="*.ts" --include="*.tsx"
+
+# try/catch with empty catch or console-only
+grep -rn "catch.*{" app/admin/ --include="*.ts" --include="*.tsx"
+```
+
+Record both per-file breakdown AND total counts for each pattern.
+
+- [ ] **Step 2: Create broken-control inventory document**
+
+Create: `docs/inventories/broken-control-inventory.md`
+
+```markdown
+# Admin Broken-Control Inventory
+
+**Generated:** 2026-03-12
+**Spec reference:** `docs/superpowers/specs/2026-03-12-admin-hybrid-rewrite-design.md`
+
+## Summary
+
+| Pattern | Count | Severity | Resolution |
+|---------|-------|----------|------------|
+| `console.log/warn/error` | (scan) | Medium | Remove in page rewrite |
+| `alert()` / `confirm()` | (scan) | High | Replace with MUI Dialog/toast |
+| `window.location` (hard nav) | (scan) | High | Replace with Next.js router |
+| Direct DOM manipulation | (scan) | Medium | Replace with React state |
+| `ignoreBuildErrors: true` | 1 | Critical | Remove in Phase 6 |
+| Middleware bypass | 1 | Critical | Rewrite in Phase 1 |
+| `reactStrictMode: false` | 1 | Medium | Enable in Phase 1 |
+
+## Global Issues
+
+### middleware.ts (line 17)
+- **Issue:** `return NextResponse.next()` bypasses all authentication
+- **Impact:** Any user can access `/admin/*` without login
+- **Resolution:** Phase 1 — rewrite with cookie-based auth
+
+### next.config.js
+- **Issue 1:** `ignoreBuildErrors: true` — TypeScript errors silently ignored in builds
+- **Issue 2:** `reactStrictMode: false` — React double-render checks disabled
+- **Issue 3:** Non-deterministic build ID (`Date.now()`) prevents caching
+- **Issue 4:** `CACHE_INVALIDATION: Date.now()` as env var
+- **Resolution:** Phase 1 (strict mode), Phase 6 (ignoreBuildErrors removal)
+
+## Per-File Breakdown
+
+| File | console | alert/confirm | window.location | Notes |
+|------|---------|---------------|-----------------|-------|
+```
+
+Populate per-file data from scan results.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/inventories/broken-control-inventory.md
+git commit -m "docs(phase-0): create broken-control inventory
+
+Catalogs all anti-patterns: console usage (59+), alert/confirm (47+),
+window.location, middleware bypass, ignoreBuildErrors, and more."
+```
+
+---
+
+### Task 6: Create auth/localStorage inventory
+
+**Files:**
+- Create: `docs/inventories/auth-localstorage-inventory.md`
+
+**Context:** Legacy admin pages rely on `localStorage` for auth tokens and state. The rewrite moves to httpOnly cookies via BFF. We need to catalog every localStorage key used, which pages read/write them, and how the LegacyPageAdapter bridge must sync them.
+
+- [ ] **Step 1: Scan all localStorage usage in admin**
+
+```bash
+# All localStorage access in admin
+grep -rn "localStorage\.\(getItem\|setItem\|removeItem\)" app/admin/ --include="*.ts" --include="*.tsx"
+
+# Auth-related localStorage in contexts
+grep -rn "localStorage\.\(getItem\|setItem\|removeItem\)" contexts/ --include="*.ts" --include="*.tsx"
+
+# Auth-related localStorage in services
+grep -rn "localStorage\.\(getItem\|setItem\|removeItem\)" app/services/ --include="*.ts" --include="*.tsx"
+
+# Auth-related localStorage in utils
+grep -rn "localStorage\.\(getItem\|setItem\|removeItem\)" utils/ --include="*.ts" --include="*.tsx"
+```
+
+- [ ] **Step 2: Create auth/localStorage inventory document**
+
+Create: `docs/inventories/auth-localstorage-inventory.md`
+
+```markdown
+# Admin Auth & localStorage Inventory
+
+**Generated:** 2026-03-12
+**Spec reference:** `docs/superpowers/specs/2026-03-12-admin-hybrid-rewrite-design.md`
+
+## localStorage Keys Used by Admin
+
+### Auth Keys (LegacyPageAdapter bridge must sync these)
+
+| Key | Type | Read By | Written By | Bridge Action |
+|-----|------|---------|------------|---------------|
+| `accessToken` | string | (verify: expected in push-notifications, dashboard, kpi-report, support-chat, member-stats) | AuthContext (login) | Sync from cookie on mount |
+| `isAdmin` | string | (verify: expected in push-notifications, dashboard, member-stats) | AuthContext (login) | Sync from session meta on mount |
+| `user` | JSON string | (verify during scan) | AuthContext (login) | Sync from session meta on mount |
+| `admin_selected_country` | string | (verify: expected in CountrySelectorModal, various pages) | CountrySelectorModal | Sync from cookie, bidirectional |
+
+**Note:** The "Read By" and "Written By" columns above are expected values based on preliminary scan. They MUST be verified by the Step 1 scan results. Update any inaccuracies found.
+
+### Non-Auth Keys (page-local state)
+
+| Key | Type | Read By | Written By | Bridge Action |
+|-----|------|---------|------------|---------------|
+| `sms_draft` | JSON string | (verify) sms/MessageComposer | sms/MessageComposer | None (page-local) |
+| `SKIPPED_USERS_KEY` | JSON array | (verify) profile-review | profile-review | None (page-local) |
+
+**Add all additional keys found during the Step 1 scan.** The rows above are preliminary — the scan is the source of truth.
+
+## Auth Flow Analysis
+
+### Current Flow (Legacy)
+1. User logs in via frontend → backend `/auth/login`
+2. Frontend stores `accessToken` in localStorage
+3. Frontend stores `user`, `isAdmin` in localStorage
+4. Axios interceptor reads `accessToken` from localStorage for API calls
+5. Pages read `isAdmin` from localStorage for access control
+
+### New Flow (Phase 1+)
+1. User logs in via BFF `/api/admin/auth/login` → backend `/auth/login`
+2. BFF stores `admin_access_token` in httpOnly cookie
+3. BFF stores `admin_session_meta` in iron-session signed cookie
+4. Admin-proxy reads cookie for API calls (no client-side token access)
+5. Middleware checks cookie for access control
+
+### Bridge Requirements (LegacyPageAdapter)
+- On mount: read session from BFF, write auth keys to localStorage
+- On country change: update both cookie (via BFF) and localStorage
+- On logout: clear both cookies (via BFF) and localStorage
+```
+
+- [ ] **Step 3: Verify completeness**
+
+Cross-check every `localStorage` reference found in the scan against the inventory. No key should be missing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/inventories/auth-localstorage-inventory.md
+git commit -m "docs(phase-0): create auth/localStorage inventory
+
+Maps all localStorage keys used by admin, categorizes as auth
+(bridge-required) vs page-local, documents current vs new auth flow."
+```
+
+---
+
+## Chunk 4: Quality Gates
+
+### Task 7: Create scoped TypeScript config for admin-v2
+
+**Files:**
+- Create: `tsconfig.admin-v2.json`
+
+**Context:** We need a separate TypeScript config that checks ONLY the new code directories. This allows us to enforce zero errors on new code while `ignoreBuildErrors: true` keeps legacy code building. The target directories don't exist yet (created in Phase 1), so this config will initially pass trivially.
+
+**Scope note:** The design spec lists `app/admin` in the typecheck scope. However, including `app/admin/**/*` in Phase 0 would pull in all 31 legacy pages with hundreds of type errors. Instead, Phase 0 includes only new directories (`features/admin`, `shared/*`, `app/api/admin`). Phase 1 will add `app/admin/layout.tsx` when it's rewritten. Each subsequent phase adds its rewritten page paths (e.g., `app/admin/dashboard/**`) by removing them from the exclude list. This way the scope grows incrementally as pages are rewritten.
+
+**`app/api/admin` scope addition:** The spec doesn't list `app/api/admin` explicitly, but BFF route handlers are new code that must be type-checked. Added for completeness.
+
+**Test file exclusion:** Test files (`*.test.ts`, `*.spec.ts`) are excluded because they are checked by `ts-jest` during `pnpm test`. This avoids duplicate error reporting. If a test has type errors, `pnpm test` will catch it.
+
+- [ ] **Step 1: Write the failing test — verify no scoped config exists**
+
+Run: `ls tsconfig.admin-v2.json 2>&1`
+Expected: `No such file or directory`
+
+- [ ] **Step 2: Create `tsconfig.admin-v2.json`**
+
+Create: `tsconfig.admin-v2.json`
+
+```json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": [
+    "app/admin/layout.tsx",
+    "features/admin/**/*.ts",
+    "features/admin/**/*.tsx",
+    "shared/auth/**/*.ts",
+    "shared/auth/**/*.tsx",
+    "shared/lib/http/**/*.ts",
+    "shared/lib/http/**/*.tsx",
+    "shared/ui/admin/**/*.ts",
+    "shared/ui/admin/**/*.tsx",
+    "app/api/admin/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
+  ]
+}
+```
+
+**Phase 1+ update:** When rewriting a page (e.g., dashboard), add its path to `include`:
+```json
+"app/admin/dashboard/**/*.ts",
+"app/admin/dashboard/**/*.tsx",
+```
+This is documented in the Phase 1 plan as a step per rewritten page.
+
+- [ ] **Step 3: Run typecheck to verify config works**
+
+Run: `pnpm tsc --project tsconfig.admin-v2.json`
+Expected: Exits 0 (no files matched yet = no errors). If tsc errors on "no input files found", that's expected — we'll create a placeholder in Step 5.
+
+- [ ] **Step 4: Create placeholder to make tsc happy**
+
+Since none of the include directories exist yet, tsc may error with "No inputs were found". Create a minimal placeholder:
+
+Create: `shared/lib/http/.gitkeep`
+
+This is a standard placeholder — it will be replaced by real code in Phase 1.
+
+If tsc still complains (`.gitkeep` is not a `.ts` file), create:
+
+Create: `shared/lib/http/index.ts`
+
+```typescript
+// Phase 1: HTTP client and React Query setup
+// This file is a placeholder created in Phase 0 to validate the quality gate config.
+export {};
+```
+
+- [ ] **Step 5: Verify typecheck passes with placeholder**
+
+Run: `pnpm tsc --project tsconfig.admin-v2.json`
+Expected: Exit 0, no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tsconfig.admin-v2.json shared/lib/http/index.ts
+git commit -m "chore(phase-0): add scoped TypeScript config for admin-v2
+
+tsconfig.admin-v2.json enforces strict checking on new code only:
+features/admin, shared/auth, shared/lib/http, shared/ui/admin, app/api/admin.
+Includes placeholder to validate the config works."
+```
+
+---
+
+### Task 8: Create scoped ESLint config and npm scripts for quality gates
+
+**Files:**
+- Create: `.eslintrc.admin-v2.json`
+- Modify: `package.json` (add scripts)
+
+**Context:** ESLint for the project uses `eslint-config-next` (configured in `package.json` or implicit). We need a scoped config that runs only on new admin code directories with stricter rules.
+
+- [ ] **Step 1: Install @typescript-eslint packages**
+
+The `.eslintrc.admin-v2.json` uses `@typescript-eslint/*` rules which require dedicated packages. These are NOT currently installed.
+
+Run: `pnpm add -D @typescript-eslint/eslint-plugin @typescript-eslint/parser`
+Expected: Both packages install successfully and `pnpm-lock.yaml` updates.
+
+- [ ] **Step 2: Check current ESLint configuration**
+
+Run: `cat package.json | grep -A5 eslint`
+Run: `ls .eslintrc* eslint.config* 2>&1`
+
+Note: No `.eslintrc.json` was found. Next.js uses `eslint-config-next` by default.
+
+- [ ] **Step 3: Create `.eslintrc.admin-v2.json`**
+
+Create: `.eslintrc.admin-v2.json`
+
+```json
+{
+  "extends": ["next/core-web-vitals"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "no-console": "error",
+    "no-alert": "error",
+    "no-restricted-globals": [
+      "error",
+      {
+        "name": "localStorage",
+        "message": "Use session hooks from shared/auth instead of localStorage directly."
+      },
+      {
+        "name": "confirm",
+        "message": "Use MUI Dialog instead of window.confirm()."
+      },
+      {
+        "name": "alert",
+        "message": "Use toast/snackbar instead of window.alert()."
+      }
+    ],
+    "no-restricted-properties": [
+      "error",
+      {
+        "object": "window",
+        "property": "location",
+        "message": "Use Next.js router instead of window.location."
+      }
+    ],
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-unused-vars": "error"
+  }
+}
+```
+
+- [ ] **Step 4: Add quality gate scripts to package.json**
+
+Modify: `package.json` — add to `scripts`:
+
+```json
+"typecheck:admin-v2": "tsc --project tsconfig.admin-v2.json",
+"lint:admin-v2": "eslint --config .eslintrc.admin-v2.json --ext .ts,.tsx features/admin/ shared/auth/ shared/lib/http/ shared/ui/admin/ app/api/admin/ --no-error-on-unmatched-pattern",
+"quality:admin-v2": "pnpm typecheck:admin-v2 && pnpm lint:admin-v2"
+```
+
+**Note on `app/admin/` scope:** The lint script intentionally excludes `app/admin/` legacy pages to avoid hundreds of existing violations. As pages are rewritten in Phase 2+, add them to the lint scope alongside the tsconfig include update.
+
+- [ ] **Step 5: Run quality gates to verify they pass**
+
+Run: `pnpm typecheck:admin-v2`
+Expected: Exit 0 (placeholder file has no errors)
+
+Run: `pnpm lint:admin-v2`
+Expected: Exit 0 (placeholder file passes all rules, `--no-error-on-unmatched-pattern` handles missing dirs)
+
+Run: `pnpm quality:admin-v2`
+Expected: Exit 0 (both pass)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .eslintrc.admin-v2.json package.json pnpm-lock.yaml
+git commit -m "chore(phase-0): add quality gate scripts for admin-v2
+
+- Install @typescript-eslint/eslint-plugin and parser
+- typecheck:admin-v2: strict TypeScript on new code only
+- lint:admin-v2: no-console, no-alert, no-localStorage, no-window.location
+- quality:admin-v2: runs both gates
+All Phase 1+ code must pass these gates before merge."
+```
+
+---
+
+### Task 9: Create Phase 0 completion checklist and verify all deliverables
+
+**Files:**
+- Create: `docs/phase-0-completion.md`
+
+**Context:** Final verification that all Phase 0 deliverables are in place before Phase 1 can begin.
+
+- [ ] **Step 1: Create completion checklist**
+
+Create: `docs/phase-0-completion.md`
+
+```markdown
+# Phase 0: Baseline and Freeze — Completion Checklist
+
+## Deliverables
+
+- [ ] `.npmrc` with `shamefully-hoist=true`
+- [ ] `pnpm install` works cleanly
+- [ ] `pnpm build` completes
+- [ ] `preinstall` script enforces pnpm-only
+- [ ] `docs/vercel-pnpm-setup.md` — Vercel configuration documented
+- [ ] `docs/admin-freeze-policy.md` — freeze rules documented
+- [ ] `docs/inventories/route-inventory.md` — 31 routes cataloged
+- [ ] `docs/inventories/api-inventory.md` — admin.ts functions cataloged
+- [ ] `docs/inventories/broken-control-inventory.md` — anti-patterns cataloged
+- [ ] `docs/inventories/auth-localstorage-inventory.md` — auth keys mapped
+- [ ] `tsconfig.admin-v2.json` — scoped strict TypeScript
+- [ ] `.eslintrc.admin-v2.json` — scoped strict ESLint
+- [ ] `pnpm typecheck:admin-v2` passes
+- [ ] `pnpm lint:admin-v2` passes
+- [ ] `pnpm quality:admin-v2` passes
+- [ ] All commits pushed to branch
+
+## Quality Gate Status
+
+```bash
+pnpm quality:admin-v2  # Must exit 0
+```
+
+## Ready for Phase 1?
+
+Phase 1 can begin when ALL items above are checked.
+Phase 1 scope: AdminShell, BFF routes, middleware rewrite, LegacyPageAdapter.
+```
+
+- [ ] **Step 2: Run final verification**
+
+```bash
+# Verify all files exist
+ls .npmrc
+ls docs/admin-freeze-policy.md
+ls docs/inventories/route-inventory.md
+ls docs/inventories/api-inventory.md
+ls docs/inventories/broken-control-inventory.md
+ls docs/inventories/auth-localstorage-inventory.md
+ls tsconfig.admin-v2.json
+ls .eslintrc.admin-v2.json
+
+# Run quality gates
+pnpm quality:admin-v2
+```
+
+Expected: All files exist, quality gate exits 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/phase-0-completion.md
+git commit -m "docs(phase-0): add completion checklist
+
+Phase 0 is complete. All inventories, freeze policy, and quality
+gates are in place. Ready for Phase 1: Foundation."
+```

--- a/docs/superpowers/specs/2026-03-12-admin-hybrid-rewrite-design.md
+++ b/docs/superpowers/specs/2026-03-12-admin-hybrid-rewrite-design.md
@@ -1,0 +1,409 @@
+# Admin Hybrid Rewrite Design Spec
+
+## 1. Overview
+
+Project-Solo 어드민 대시보드(31개 페이지, 157개 파일)를 하이브리드 점진 전환 방식으로 재구축한다.
+한 번에 전부 바꾸지 않고, 새 껍데기(Shell)를 먼저 세운 뒤 페이지를 하나씩 새 버전으로 교체한다.
+
+### Decision Record
+
+- **전환 방식**: 하이브리드 점진 전환 (big-bang 거부)
+- **UI**: MUI 중심 + Tailwind 보조 (MUI는 shared component layer 뒤에 숨김)
+- **런타임**: Next.js 14 / React 18 유지 (리팩토링 완료 후 별도 업그레이드)
+- **데이터**: React Query (신규 설치)
+- **폼**: react-hook-form + zod (신규 설치)
+- **운영 정책**: 기존 어드민은 긴급 수정만 허용
+- **리소스**: 사실상 1인
+
+### Why
+
+- 로그인 보안이 무력화됨 (middleware.ts line 17에서 `NextResponse.next()` 즉시 반환)
+- 코드 유지보수 불가 상태 (`admin.ts` 4,756줄, console.log 83개 파일)
+- 유지보수/리팩토링 없이 코드만 추가해와서 자주 고장나고 고치기 어려움
+- 새 기능 추가 시 버그 위험 높음
+
+### Constraints
+
+- **백엔드(sometimes-api) 수정 금지**: 프로덕션 앱과 공유하는 서버이므로 수정 시 앱 전체가 터질 위험
+- **별도 중간 프로젝트 금지**: 과거 별도 middle-layer 프로젝트를 두었다가 라우팅 혼란으로 프로덕션 터진 경험 있음. BFF는 반드시 Project-Solo 내부 route handler로만 구현
+- **배포 단위는 Project-Solo 하나만 유지**
+
+### Scope
+
+- **포함**: 어드민 대시보드 31개 페이지 전체
+- **제외**: 일반 사용자 페이지, 백엔드 API 계약 변경, 런타임 업그레이드
+
+---
+
+## 2. Current Baseline (코드베이스 탐색 결과)
+
+| 항목 | 현재 상태 |
+|------|-----------|
+| Admin 디렉토리 | 31개 |
+| Admin 파일 수 | 157개 |
+| `app/services/admin.ts` | 4,756줄 |
+| `'use client'` in admin | 103개 파일 |
+| middleware 보호 | 우회됨 (line 17 즉시 반환) |
+| `app/layout.tsx` | Client Component (anti-pattern) |
+| `app/admin/layout.tsx` | Client Component, client-side admin 체크 |
+| react-query | 미설치 |
+| react-hook-form | 미설치 |
+| zod | 미설치 |
+| `features/admin` | 미존재 |
+| `shared/auth` | 미존재 |
+| `shared/ui/admin` | 미존재 |
+| `shared/lib/http` | 미존재 |
+| BFF routes (`app/api/admin/`) | 미존재 |
+| 기존 문서 | `docs/ADMIN_MIGRATION_INVENTORY.md` 존재 (참고용) |
+
+---
+
+## 3. Transitional Architecture
+
+### 3.1 BFF / Session Mechanism
+
+백엔드 변경 없이 프론트엔드 내부에 보안 경계를 세운다.
+Project-Solo 내부 route handler(`app/api/admin/`)로만 구현한다. 별도 프로젝트/서버 금지.
+
+**CRITICAL: next.config.js rewrite 충돌 해결**
+
+현재 `next.config.js`에 `{ source: '/api/admin/:path*', destination: '${backendUrl}/admin/:path*' }` rewrite 규칙이 있다. 이 규칙이 BFF route handler보다 먼저 실행되어 모든 `/api/admin/*` 요청을 백엔드로 프록시해버린다. Phase 1에서 반드시 해결해야 한다.
+
+**해결 방식:** 기존 catch-all rewrite를 제거하고, BFF route handler가 처리하지 않는 레거시 엔드포인트만 개별 rewrite로 전환한다. `admin-proxy`가 이 역할을 대체하므로 기존 rewrite는 최종적으로 불필요해진다.
+
+**신규 route handlers:**
+
+| Route | Method | 역할 |
+|-------|--------|------|
+| `/api/admin/auth/login` | POST | 백엔드 `/auth/login` 프록시 → admin 확인 → httpOnly cookie 발급 |
+| `/api/admin/auth/logout` | POST | cookie 정리 |
+| `/api/admin/session` | GET | cookie 기반 토큰 유효성 검증, session DTO 반환 |
+| `/api/admin/session/country` | POST | selectedCountry 변경 → meta cookie 재서명 |
+| `/api/admin-proxy/[...path]` | ALL | cookie에서 token 읽어 백엔드로 Authorization + x-country 헤더 전달 |
+
+**동작 규약:**
+
+- `login`: 백엔드 `/auth/login` 프록시 → 응답의 `user/roles`에서 admin 확인 → admin이 아니면 403 → admin이면 `admin_access_token`을 `httpOnly`, `secure`, `sameSite=lax` cookie로 저장 + `admin_session_meta`를 서버 서명 cookie로 저장 (id, email, roles, issuedAt, selectedCountry만 포함)
+- `session`: cookie 읽고 → `admin_access_token`으로 기존 `/profile` 호출 → 성공 시 session DTO 반환, 실패 시 cookie 정리 + 401
+- `admin-proxy`: cookie에서 access token 읽어 → `Authorization` 헤더 붙여 전달. `admin_session_meta`에서 `selectedCountry`를 읽어 `x-country` 헤더로 전달. v2 페이지는 이 proxy를 통해 country context를 자동 전달받음.
+- `session/country`: 클라이언트에서 country 변경 시 호출. `admin_session_meta` cookie를 재서명하여 `selectedCountry` 갱신. LegacyPageAdapter의 bridge도 localStorage를 동시 갱신.
+
+**Cookie 서명 방식:**
+
+- `iron-session` 라이브러리 사용 (Next.js route handler 전용, 경량)
+- `admin_access_token`: httpOnly, secure, sameSite=lax cookie에 그대로 저장
+- `admin_session_meta`: iron-session으로 암호화/서명 (id, email, roles, issuedAt, selectedCountry)
+- 서명 secret: 환경변수 `ADMIN_SESSION_SECRET`에 저장
+- middleware에서는 `admin_session_meta` cookie 존재 여부만 확인 (서명 검증은 route handler에서)
+
+**명시적 제한:**
+
+- Phase 1에서 silent refresh 미지원
+- 세션 TTL: 8시간 (현재 프론트 기준)
+- 토큰 만료 시 재로그인 요구
+- 백엔드가 추후 refresh endpoint 제공 시 BFF 내부만 교체 (page contract 유지)
+
+### 3.2 LegacyPageAdapter
+
+새 Shell 안에서 기존 페이지를 임시 운영하는 과도기 컴포넌트.
+단위는 페이지 전체. 개별 레거시 child component를 새 feature tree에 섞지 않음.
+
+**각 레거시 route 구조:**
+```
+AdminShell
+  └─ LegacyAuthBridgeProvider
+       └─ LegacyCountryBridgeProvider
+            └─ Error Boundary + Toast + Page Frame
+                 └─ 기존 페이지 컴포넌트
+```
+
+**Bridge 규약:**
+
+- 새 server-owned session 기준으로 레거시 localStorage 키를 mount 시 동기화:
+  - `accessToken`, `user`, `isAdmin`, `admin_selected_country`
+- country 변경 시 cookie와 legacy localStorage 동시 갱신
+- logout 시 cookie와 legacy localStorage 모두 정리
+
+**종료 조건:** 각 route가 새 feature 구현으로 승격되면 adapter 제거. 최종 단계에서 adapter 0개.
+
+### 3.3 Feature Flags / Rollback
+
+| Flag | 범위 | 용도 |
+|------|------|------|
+| `admin_shell_v2` | 전체 Shell | Shell 문제 시 false로 즉시 복귀 |
+| `admin_route_mode.<route>` | 개별 페이지 | `legacy` → `legacy-adapted` → `v2` 전환 |
+
+**Feature Flag 구현:**
+
+- **저장소:** Supabase `admin_feature_flags` 테이블 (key text, value text, updated_at timestamp)
+- **읽기:** 서버 측에서 middleware/layout에서 읽음. 클라이언트에는 layout에서 props로 전달.
+- **변경:** Supabase 테이블 직접 수정 (배포 불필요, 즉시 반영)
+- **캐시:** 서버 측에서 요청당 1회 조회, 1분 캐시. 긴급 rollback 시 최대 1분 이내 반영.
+- **이유:** 환경변수 방식은 Vercel 재배포(2~3분)가 필요하므로 "5분 내 rollback" 불가. DB 기반은 배포 없이 즉시 가능.
+
+**Rollback 규칙:**
+- Shell 문제 → `admin_shell_v2=false` (DB에서 변경, 1분 내 반영)
+- 개별 route 문제 → 해당 route만 `legacy-adapted` 또는 `legacy`로 즉시 복귀
+- `matching-management` 같이 구조가 크게 바뀌는 route는 최소 1 wave 동안 legacy fallback 유지
+- rollback은 DB flag 변경만으로 1분 내 완료
+
+---
+
+## 4. Phased Plan
+
+### Phase 0: Baseline and Freeze (1~2주)
+
+**목표:** 현황 파악, 작업 규칙 확립
+
+- pnpm 단일화:
+  - `package-lock.json` 제거, `pnpm-lock.yaml` 생성
+  - `.npmrc`에 `shamefully-hoist=true` 설정 (MUI/Emotion hoisting 호환)
+  - Vercel build 설정에서 install command를 `pnpm install`로 변경
+  - 모든 의존성 정상 resolve 확인
+- 기존 어드민 freeze 정책 문서화
+- 신규 inventory 작성 (기존 ADMIN_MIGRATION_INVENTORY.md는 참고만):
+  - route inventory (31개 페이지 전수조사)
+  - API inventory (admin.ts 4,756줄 분석)
+  - broken-control inventory (무법 코드 목록)
+  - auth/localStorage inventory
+- 품질 게이트 정의:
+  - `typecheck:admin-v2` (범위: `app/admin`, `features/admin`, `shared/auth`, `shared/ui/admin`, `shared/lib/http`)
+  - `lint:admin-v2`
+- `ignoreBuildErrors`는 Phase 0 동안만 유지 (레거시 오류 때문에 foundation 착수 불가 방지)
+- 신규 코드 범위에는 오류 0 강제
+
+### Phase 1: Foundation (2~3주)
+
+**목표:** 새 Shell + 보안 + 모든 기존 페이지가 새 Shell 안에서 동작
+
+- `app/layout.tsx` → Server Component로 복귀
+- `app/admin/layout.tsx` → 새 `AdminShell`로 교체
+- `middleware.ts` → cookie 기반 보호 로직을 처음부터 새로 작성 (기존 주석 처리된 코드는 header 기반이라 재사용 불가)
+- `shared/auth`, `shared/lib/http`, `shared/ui/admin` 생성
+- BFF route handlers 도입 (`app/api/admin/`)
+- `next.config.js` rewrite 규칙 마이그레이션: `/api/admin/:path*` catch-all 제거 → BFF route handler가 처리
+- `LegacyPageAdapter` 도입
+- `next.config.js` 정리 (dev hack 제거, reactStrictMode 활성화)
+- 신규 의존성 설치:
+  - `@tanstack/react-query` (서버 상태 관리)
+  - `react-hook-form` + `zod` + `@hookform/resolvers` (폼/검증)
+  - `iron-session` (cookie 서명)
+  - `@testing-library/react` + `@testing-library/jest-dom` (테스트)
+  - `playwright` (E2E 테스트, Phase 2부터 사용)
+- TypeScript 5.3으로 마이너 업그레이드 (zod, react-query가 TS 5.x 기능 필요. 컴파일 전용, 런타임 변경 없음)
+
+**완료 조건:**
+- `/admin/*` 전체가 새 Shell 아래서 동작
+- 레거시 페이지도 adapter를 통해 새 Shell에서 열림
+- 신규 foundation 코드의 lint/typecheck 0
+
+### Phase 2: Prove the Foundation (1~2주)
+
+**목표:** 새 패턴이 실제로 동작함을 증명
+
+**대상:** `dashboard`, `kpi-report`
+
+- server session + BFF + React Query + 공통 page template 패턴 검증
+- chart/table/filter/status UI 규약 검증
+
+**완료 조건:**
+- 두 route가 `v2`로 승격
+- route flag로 legacy/v2 전환 가능
+- 공통 shell과 feedback contract 안정화
+
+### Phase 3A: High-Risk Operational Pages (3~4주)
+
+**목표:** 가장 자주 쓰는 운영 페이지 전환
+
+**대상:** `users`, `profile-review`, `push-notifications`
+
+**특별 규칙:**
+- fake filter 금지
+- `alert/confirm/window.location.href` 금지
+- browser-local 운영 상태 금지
+- page 파일에서 fetch/pagination/filter/modal/mutation 동시 구현 금지
+
+**완료 조건:**
+- 각 route에 integration test 존재
+- route flags로 즉시 rollback 가능
+
+### Phase 3B: Matching Management Rewrite (3~4주)
+
+**목표:** 가장 복잡한 페이지를 안전하게 분해
+
+**대상:** `matching-management`
+
+- 거대 단일 페이지를 작업별 sub-route 또는 workflow page로 분해
+- 최소 1 wave 동안 legacy fallback 유지
+- Phase 3A에서 패턴이 안정된 뒤 착수
+
+### Phase 4: Messaging and Moderation (3~4주)
+
+**대상:** `reports`, `sms`, `support-chat`, `community`
+
+- moderation, queue, bulk action, messaging UX 표준화
+- reusable split-pane / queue / compose patterns 정립
+
+### Phase 5: Remaining Domains (3~5주)
+
+**대상 (21개 페이지):**
+
+| Route | 카테고리 |
+|-------|----------|
+| `sales` | 수익 |
+| `scheduled-matching` | 매칭 |
+| `force-matching` | 매칭 |
+| `universities` | 데이터 |
+| `card-news` | 콘텐츠 |
+| `banners` | 콘텐츠 |
+| `sometime-articles` | 콘텐츠 |
+| `ai-chat` | 기능 |
+| `moment` | 기능 |
+| `chat` | 소통 |
+| `likes` | 데이터 |
+| `dormant-likes` | 데이터 |
+| `deleted-females` | 데이터 |
+| `female-retention` | 데이터 |
+| `fcm-tokens` | 시스템 |
+| `gems` | 수익 |
+| `ios-refund` | 수익 |
+| `reset-password` | 시스템 |
+| `app-reviews` | 콘텐츠 |
+| `version-management` | 시스템 |
+| `lab` | 실험 |
+
+- legacy adapter 의존 빠르게 축소
+
+### Phase 6: Legacy Removal and Global Gate Restoration (1~2주)
+
+- `app/services/admin.ts` 제거
+- old auth/session/localStorage trust 제거
+- old adapters 제거
+- production admin 코드 `console.log` 제거
+- 전역 `ignoreBuildErrors` 제거
+- 최종 보안 점검
+
+---
+
+## 5. New Directory Structure
+
+```
+app/
+├── api/admin/                    # BFF route handlers (NEW)
+│   ├── auth/login/route.ts
+│   ├── auth/logout/route.ts
+│   ├── session/route.ts
+│   ├── session/country/route.ts
+│   └── admin-proxy/[...path]/route.ts
+├── admin/
+│   ├── layout.tsx                # AdminShell (REWRITE)
+│   ├── dashboard/page.tsx        # Phase 2 rewrite
+│   ├── kpi-report/page.tsx       # Phase 2 rewrite
+│   └── ...                       # Other pages (phased rewrite)
+├── layout.tsx                    # Server Component (REWRITE)
+└── ...
+
+features/admin/                   # Feature modules (NEW)
+├── dashboard/
+├── kpi-report/
+├── users/
+└── ...
+
+shared/                           # Shared modules (NEW)
+├── auth/                         # Session, auth hooks
+├── lib/http/                     # HTTP client, React Query setup
+└── ui/admin/                     # Admin shared components (MUI wrapped)
+```
+
+---
+
+## 6. Tech Stack Changes
+
+| Category | Before | After |
+|----------|--------|-------|
+| Server State | Direct axios in components | React Query hooks |
+| Forms | Raw controlled inputs | react-hook-form + zod |
+| Auth | localStorage + client-side check | httpOnly cookie + BFF + middleware |
+| Layout | Client Component root | Server Component root + client Shell |
+| Error Handling | console.log + alert() | Error boundary + toast |
+| API Layer | `admin.ts` 4,756줄 monolith | Feature-scoped query/mutation hooks |
+
+---
+
+## 7. Test Plan
+
+**기본 게이트:**
+- `pnpm lint`
+- `pnpm typecheck:admin-v2`
+- `pnpm test`
+- rewritten routes 기준 `pnpm build`
+
+**Unit/Integration (Jest/RTL):**
+- `shared/auth` (session, hooks)
+- BFF handlers (login, logout, session, proxy)
+- React Query hooks
+- shared admin components
+- `LegacyPageAdapter` bridge 동기화
+
+**E2E (Playwright):**
+- admin login/logout
+- 비관리자 접근 차단
+- dashboard / kpi-report
+- users filter
+- profile-review actions
+- push-notification dry-run/send
+- matching-management 핵심 작업
+
+---
+
+## 8. Monitoring
+
+**최소 수집 항목:**
+- `/api/admin/session` 401 비율
+- `/api/admin-proxy/*` 5xx 비율
+- route-level render error 수
+- mutation failure rate
+- route flag별 traffic 비율
+- fallback-to-legacy 횟수
+
+**구현:** server route structured logs + client error boundary reporting
+
+**목표:** 새 route가 legacy보다 에러율이 높으면 즉시 rollback 판단 가능
+
+---
+
+## 9. Rollout / Rollback
+
+- rollout은 route 단위로만 진행
+- 한 번에 1~2개 route만 승격
+- rollback은 flag 전환만으로 5분 내 완료
+- route structure 변경 시에도 legacy fallback URL은 1 wave 유지
+
+---
+
+## 10. Timeline
+
+모든 phase는 **순차 진행** (1인 팀이므로 병렬 불가).
+
+| Phase | Duration | Cumulative (min) | Cumulative (max) |
+|-------|----------|-------------------|-------------------|
+| Phase 0 | 1~2주 | 1주 | 2주 |
+| Phase 1 | 2~3주 | 3주 | 5주 |
+| Phase 2 | 1~2주 | 4주 | 7주 |
+| Phase 3A | 3~4주 | 7주 | 11주 |
+| Phase 3B | 3~4주 | 10주 | 15주 |
+| Phase 4 | 3~4주 | 13주 | 19주 |
+| Phase 5 | 3~5주 | 16주 | 24주 |
+| Phase 6 | 1~2주 | 17주 | 26주 |
+
+**총 예상: 17~26주 (약 4~6개월)**
+
+Phase 5의 페이지가 21개로 확대되었으므로 상한(5주)에 가까울 가능성이 높음.
+
+### Assumptions
+
+- 사실상 1인 진행
+- 기존 어드민은 긴급 수정만
+- 백엔드 API 계약 변경은 범위 밖
+- silent refresh는 후순위
+- MUI는 shared component layer 뒤에 숨겨서 vendor coupling 축소

--- a/docs/vercel-pnpm-setup.md
+++ b/docs/vercel-pnpm-setup.md
@@ -1,0 +1,16 @@
+# Vercel pnpm Build Settings
+
+## Required Vercel Project Settings
+
+| Setting | Value |
+|---------|-------|
+| Framework Preset | Next.js |
+| Build Command | `pnpm build` |
+| Install Command | `pnpm install` |
+| Node.js Version | 18.x |
+
+## Notes
+
+- `.npmrc` with `shamefully-hoist=true` is required for MUI/Emotion compatibility.
+- `package-lock.json` has been removed. Only `pnpm-lock.yaml` is used.
+- `preinstall` script enforces pnpm-only via `only-allow`.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "commonjs",
   "private": true,
   "scripts": {
+    "preinstall": "npx only-allow pnpm",
     "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "start": "next start",
     "lint": "next lint",
     "matching": "ts-node scripts/matching-cron.ts",
-    "test": "jest"
+    "test": "jest",
+    "typecheck:admin-v2": "tsc --project tsconfig.admin-v2.json",
+    "lint:admin-v2": "ESLINT_USE_FLAT_CONFIG=false eslint --config .eslintrc.admin-v2.json --ext .ts,.tsx features/admin/ shared/auth/ shared/lib/http/ shared/ui/admin/ app/api/admin/ --no-error-on-unmatched-pattern",
+    "quality:admin-v2": "pnpm typecheck:admin-v2 && pnpm lint:admin-v2"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -69,6 +72,8 @@
     "@types/react-dom": "^18",
     "@types/react-slick": "^0.23.13",
     "@types/uuid": "^9.0.8",
+    "@typescript-eslint/eslint-plugin": "^8.57.0",
+    "@typescript-eslint/parser": "^8.57.0",
     "autoprefixer": "^10.4.21",
     "dotenv": "^16.4.7",
     "eslint": "^8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,12 @@ importers:
       '@types/uuid':
         specifier: ^9.0.8
         version: 9.0.8
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.57.0
+        version: 8.57.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/parser':
+        specifier: ^8.57.0
+        version: 8.57.0(eslint@8.57.1)(typescript@4.9.5)
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.3)
@@ -912,8 +918,18 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
   '@eslint-community/regexpp@4.12.1':
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   '@eslint/eslintrc@2.1.4':
@@ -1834,6 +1850,14 @@ packages:
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
 
+  '@typescript-eslint/eslint-plugin@8.57.0':
+    resolution: {integrity: sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.57.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/parser@6.21.0':
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -1844,13 +1868,47 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/parser@8.57.0':
+    resolution: {integrity: sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/project-service@8.57.0':
+    resolution: {integrity: sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/scope-manager@6.21.0':
     resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
+  '@typescript-eslint/scope-manager@8.57.0':
+    resolution: {integrity: sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.57.0':
+    resolution: {integrity: sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.57.0':
+    resolution: {integrity: sha512-yjgh7gmDcJ1+TcEg8x3uWQmn8ifvSupnPfjP21twPKrDP/pTHlEQgmKcitzF/rzPSmv7QjJ90vRpN4U+zoUjwQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/types@6.21.0':
     resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
     engines: {node: ^16.0.0 || >=18.0.0}
+
+  '@typescript-eslint/types@8.57.0':
+    resolution: {integrity: sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@6.21.0':
     resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
@@ -1861,9 +1919,26 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/typescript-estree@8.57.0':
+    resolution: {integrity: sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.57.0':
+    resolution: {integrity: sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/visitor-keys@6.21.0':
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
+
+  '@typescript-eslint/visitor-keys@8.57.0':
+    resolution: {integrity: sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -2123,6 +2198,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -2135,6 +2214,10 @@ packages:
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2721,6 +2804,10 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2801,6 +2888,15 @@ packages:
 
   fdir@6.4.3:
     resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -3037,6 +3133,10 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   import-fresh@3.3.1:
@@ -3565,6 +3665,10 @@ packages:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
 
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -3799,6 +3903,10 @@ packages:
 
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
   pify@2.3.0:
@@ -4154,6 +4262,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -4393,6 +4506,10 @@ packages:
     resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -4416,6 +4533,12 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
+
+  ts-api-utils@2.4.0:
+    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -5647,7 +5770,14 @@ snapshots:
       eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
+    dependencies:
+      eslint: 8.57.1
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
@@ -6621,6 +6751,22 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
+  '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.57.0(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/type-utils': 8.57.0(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/utils': 8.57.0(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/visitor-keys': 8.57.0
+      eslint: 8.57.1
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.4.0(typescript@4.9.5)
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
@@ -6634,12 +6780,56 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@4.9.5)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@4.9.5)
+      '@typescript-eslint/visitor-keys': 8.57.0
+      debug: 4.4.3
+      eslint: 8.57.1
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.57.0(typescript@4.9.5)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@4.9.5)
+      '@typescript-eslint/types': 8.57.0
+      debug: 4.4.3
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@6.21.0':
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
 
+  '@typescript-eslint/scope-manager@8.57.0':
+    dependencies:
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/visitor-keys': 8.57.0
+
+  '@typescript-eslint/tsconfig-utils@8.57.0(typescript@4.9.5)':
+    dependencies:
+      typescript: 4.9.5
+
+  '@typescript-eslint/type-utils@8.57.0(eslint@8.57.1)(typescript@4.9.5)':
+    dependencies:
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@4.9.5)
+      '@typescript-eslint/utils': 8.57.0(eslint@8.57.1)(typescript@4.9.5)
+      debug: 4.4.3
+      eslint: 8.57.1
+      ts-api-utils: 2.4.0(typescript@4.9.5)
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@6.21.0': {}
+
+  '@typescript-eslint/types@8.57.0': {}
 
   '@typescript-eslint/typescript-estree@6.21.0(typescript@4.9.5)':
     dependencies:
@@ -6656,10 +6846,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.57.0(typescript@4.9.5)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.57.0(typescript@4.9.5)
+      '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@4.9.5)
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/visitor-keys': 8.57.0
+      debug: 4.4.3
+      minimatch: 10.2.4
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@4.9.5)
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.57.0(eslint@8.57.1)(typescript@4.9.5)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@4.9.5)
+      eslint: 8.57.1
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@6.21.0':
     dependencies:
       '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@8.57.0':
+    dependencies:
+      '@typescript-eslint/types': 8.57.0
+      eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -6957,6 +7178,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   binary-extensions@2.3.0: {}
 
   boolbase@1.0.0: {}
@@ -6969,6 +7192,10 @@ snapshots:
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.4:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -7525,8 +7752,8 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@4.9.5)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -7545,7 +7772,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -7556,22 +7783,21 @@ snapshots:
       stable-hash: 0.0.5
       tinyglobby: 0.2.12
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/parser': 8.57.0(eslint@8.57.1)(typescript@4.9.5)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -7582,7 +7808,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7594,7 +7820,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/parser': 8.57.0(eslint@8.57.1)(typescript@4.9.5)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -7651,6 +7877,8 @@ snapshots:
       estraverse: 5.3.0
 
   eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@8.57.1:
     dependencies:
@@ -7772,6 +8000,10 @@ snapshots:
   fdir@6.4.3(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   fetch-blob@3.2.0:
     dependencies:
@@ -8014,6 +8246,8 @@ snapshots:
       safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -8742,6 +8976,10 @@ snapshots:
 
   mini-svg-data-uri@1.4.4: {}
 
+  minimatch@10.2.4:
+    dependencies:
+      brace-expansion: 5.0.4
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -8975,6 +9213,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  picomatch@4.0.3: {}
 
   pify@2.3.0: {}
 
@@ -9355,6 +9595,8 @@ snapshots:
 
   semver@7.7.1: {}
 
+  semver@7.7.4: {}
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -9656,6 +9898,11 @@ snapshots:
       fdir: 6.4.3(picomatch@4.0.2)
       picomatch: 4.0.2
 
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
   tmpl@1.0.5: {}
 
   to-regex-range@5.0.1:
@@ -9676,6 +9923,10 @@ snapshots:
       punycode: 2.3.1
 
   ts-api-utils@1.4.3(typescript@4.9.5):
+    dependencies:
+      typescript: 4.9.5
+
+  ts-api-utils@2.4.0(typescript@4.9.5):
     dependencies:
       typescript: 4.9.5
 

--- a/shared/lib/http/index.ts
+++ b/shared/lib/http/index.ts
@@ -1,0 +1,3 @@
+// Phase 1: HTTP client and React Query setup
+// This file is a placeholder created in Phase 0 to validate the quality gate config.
+export {};

--- a/tsconfig.admin-v2.json
+++ b/tsconfig.admin-v2.json
@@ -1,0 +1,27 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": [
+    "features/admin/**/*.ts",
+    "features/admin/**/*.tsx",
+    "shared/auth/**/*.ts",
+    "shared/auth/**/*.tsx",
+    "shared/lib/http/**/*.ts",
+    "shared/lib/http/**/*.tsx",
+    "shared/ui/admin/**/*.ts",
+    "shared/ui/admin/**/*.tsx",
+    "app/api/admin/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
+  ]
+}


### PR DESCRIPTION
## Summary

Admin Hybrid Rewrite Phase 0 — 프로젝트 기준선 설정 및 레거시 코드 동결.

- pnpm 단일 패키지 매니저로 확정 (`.npmrc` + `preinstall` 강제)
- 레거시 어드민 코드 freeze 정책 문서화
- 4가지 inventory 작성:
  - **Route inventory:** 31개 어드민 페이지 Phase별 분류
  - **API inventory:** `admin.ts` 163개 함수, 29개 도메인 그룹 카탈로그
  - **Broken-control inventory:** console 339건, alert 121건, confirm 26건 등 안티패턴 목록
  - **Auth/localStorage inventory:** 브릿지 필요 키 5개, 보안 이슈 식별
- 품질 게이트 정의:
  - `tsconfig.admin-v2.json` — 신규 코드 전용 strict TypeScript
  - `.eslintrc.admin-v2.json` — no-console, no-alert, no-localStorage, no-window.location
  - `pnpm quality:admin-v2` 스크립트 (typecheck + lint 통합)

### 주요 발견 사항
- `scheduled-matching/service.ts`가 `admin.ts` 외부에 15개 endpoint 독립 서비스로 존재
- `utils/axios.ts`가 accessToken을 non-httpOnly cookie에 기록 (Phase 1 보안 수정 대상)
- `eslint.config.mjs` 존재로 `ESLINT_USE_FLAT_CONFIG=false` 우회 필요

## Test plan

- [x] `pnpm install` 정상 동작
- [x] `pnpm build` 완료 (ignoreBuildErrors 유지)
- [x] `pnpm quality:admin-v2` exit 0
- [x] 모든 inventory 파일 존재 및 completeness 검증
- [ ] Vercel 배포 설정 확인 (pnpm build command)

🤖 Generated with [Claude Code](https://claude.com/claude-code)