### PR TITLE
fix(admin): remove z-index stacking that blocked sidebar navigation

### DIFF
--- a/shared/ui/admin/admin-shell.tsx
+++ b/shared/ui/admin/admin-shell.tsx
@@ -151,7 +151,7 @@ export function AdminShell({ children }: { children: ReactNode }) {
               />
             )}
 
-            <div className="relative z-0 flex min-w-0 flex-1 flex-col overflow-auto">
+            <div className="flex min-w-0 flex-1 flex-col overflow-auto">
               <div className="md:hidden flex items-center justify-between p-4 bg-white shadow-sm">
                 <h1 className="text-lg font-semibold">관리자 대시보드</h1>
                 <button


### PR DESCRIPTION
## Summary
- 어드민 사이드바 네비게이션 클릭이 안 되는 버그 수정
- 콘텐츠 영역의 `relative z-0`이 사이드바 위에 겹쳐 클릭 이벤트를 가로채는 문제 해결

## Test plan
- [ ] 데스크톱에서 사이드바 링크 클릭 시 페이지 이동 확인
- [ ] 모바일에서 사이드바 오버레이 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)