### PR TITLE
fix: prevent crash when genderRatio is undefined

### DIFF
--- a/components/admin/dashboard/GenderStatsCard.tsx
+++ b/components/admin/dashboard/GenderStatsCard.tsx
@@ -285,7 +285,7 @@ export default function GenderStatsCard({
               sx={{ backgroundColor: MALE_COLOR }}
             />
             <Typography className="font-semibold text-slate-700">
-              {stats.genderRatio.split(":")[0]}
+              {(stats.genderRatio || '0:0').split(":")[0]}
             </Typography>
           </Box>
           <Typography className="text-slate-300 font-light text-lg">
@@ -293,7 +293,7 @@ export default function GenderStatsCard({
           </Typography>
           <Box className="flex items-center gap-1.5">
             <Typography className="font-semibold text-slate-700">
-              {stats.genderRatio.split(":")[1]}
+              {(stats.genderRatio || '0:0').split(":")[1]}
             </Typography>
             <Box
               className="w-3 h-3 rounded-full"


### PR DESCRIPTION
## Summary
- `GenderStatsCard`에서 `stats.genderRatio`가 undefined일 때 `.split()` 호출로 크래시 발생
- Slack 에러 알림: `Cannot read properties of undefined (reading 'split')`
- `stats.genderRatio || '0:0'` 기본값 추가로 수정

## Test plan
- [ ] member-stats 페이지 정상 로드 확인
- [ ] Slack 에러 알림 중단 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)