### PR TITLE
fix: add WebSocket support to CSP headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Content-Security-Policy',
-            value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https: http:; connect-src 'self' https: http:; font-src 'self' data: https:; frame-src 'self' https:;",
+            value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https: http:; connect-src 'self' https: http: wss: ws:; font-src 'self' data: https:; frame-src 'self' https:;",
           },
           {
             key: 'X-Frame-Options',


### PR DESCRIPTION
## Summary
- CSP `connect-src`에 `wss:` `ws:` 프로토콜 추가
- Q&A 처리 페이지 WebSocket 연결 차단 해결

## Test plan
- [ ] Q&A 처리 페이지 WebSocket 연결 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)