### PR TITLE
feat(admin): Admin API v1 → v2 마이그레이션

### DIFF
--- a/app/admin/ai-chat/ai-chat-v2.tsx
+++ b/app/admin/ai-chat/ai-chat-v2.tsx
@@ -153,7 +153,9 @@ function AIChatManagementPageContent() {
     }
   };
 
-  const selectedSession = messagesData?.session ?? null;
+  const selectedSession = messagesData?.session
+    ?? sessions.find((s: AIChatSession) => s.id === selectedSessionId)
+    ?? null;
   const messages = messagesData?.messages ?? [];
 
   return (

--- a/app/admin/chat/components/ChatManagementTab.tsx
+++ b/app/admin/chat/components/ChatManagementTab.tsx
@@ -117,11 +117,11 @@ export default function ChatManagementTab() {
 
       const response = await chatService.getChatRooms(params);
 
-      setChatRooms(response.chatRooms);
-      setTotalCount(response.total);
+      setChatRooms(response?.chatRooms ?? []);
+      setTotalCount(response?.total ?? 0);
       setAppliedDateRange({
-        start: response.appliedStartDate,
-        end: response.appliedEndDate
+        start: response?.appliedStartDate ?? '',
+        end: response?.appliedEndDate ?? ''
       });
     } catch (error: any) {
       setError(error.message || '채팅방 목록을 불러오는데 실패했습니다.');
@@ -140,7 +140,7 @@ export default function ChatManagementTab() {
         limit: 50
       });
 
-      setChatMessages(response.messages);
+      setChatMessages(response?.messages ?? []);
     } catch (error: any) {
       setError(error.message || '채팅 메시지를 불러오는데 실패했습니다.');
     } finally {

--- a/app/admin/dashboard/components/ActionRequired.tsx
+++ b/app/admin/dashboard/components/ActionRequired.tsx
@@ -119,7 +119,7 @@ export default function ActionRequired() {
       try {
         setReviewLoading(true);
         const response = await AdminService.userReview.getPendingUsers(1, 1);
-        setPendingReview(response.pagination?.total ?? 0);
+        setPendingReview(response.meta?.total ?? 0);
       } catch (error) {
         setPendingReview(0);
       } finally {
@@ -135,7 +135,7 @@ export default function ActionRequired() {
         params.append("limit", "1");
         params.append("status", "pending");
         const response = await AdminService.getProfileReports(params);
-        setPendingReports(response.meta?.totalItems ?? 0);
+        setPendingReports(response.meta?.total ?? 0);
       } catch (error) {
         setPendingReports(0);
       } finally {

--- a/app/admin/profile-review/profile-review-v2.tsx
+++ b/app/admin/profile-review/profile-review-v2.tsx
@@ -139,12 +139,12 @@ export interface PendingUser {
 }
 
 export interface PendingUsersResponse {
-  users: PendingUser[];
-  pagination: {
+  data: PendingUser[];
+  meta: {
     page: number;
     limit: number;
     total: number;
-    hasMore: boolean;
+    totalPages: number;
   };
 }
 
@@ -280,14 +280,14 @@ function ProfileReviewV2Content() {
 
       ;
 
-      if (!response || !response.users) {
+      if (!response || !response.data) {
         throw new Error(
-          "API 응답 형식이 올바르지 않습니다. users 배열이 없습니다.",
+          "API 응답 형식이 올바르지 않습니다. data 배열이 없습니다.",
         );
       }
 
       // 응답 데이터 정규화 (UI 호환성을 위한 추가 필드)
-      const normalizedUsers: PendingUser[] = response.users.map((user) => {
+      const normalizedUsers: PendingUser[] = response.data.map((user) => {
         // 전체 이미지 URL 목록 (승인된 이미지 + 대기 중인 이미지)
         const allImageUrls = [
           ...(user.approvedImageUrls || []),
@@ -310,7 +310,12 @@ function ProfileReviewV2Content() {
       ;
 
       setUsers(normalizedUsers);
-      setPagination(response.pagination);
+      setPagination(response.meta ? {
+        page: response.meta.page,
+        limit: response.meta.limit,
+        total: response.meta.total,
+        hasMore: response.meta.page < response.meta.totalPages,
+      } : { page: 1, limit: 20, total: 0, hasMore: false });
       return normalizedUsers;
     } catch (err: any) {
 

--- a/app/admin/reports/reports-v2.tsx
+++ b/app/admin/reports/reports-v2.tsx
@@ -189,7 +189,7 @@ function ReportsManagementContent() {
 
       if (response?.items) {
         setReports(response.items);
-        setTotalCount(response.meta.totalItems);
+        setTotalCount(response.meta?.total ?? 0);
       } else {
         setReports([]);
         setTotalCount(0);

--- a/app/services/admin/dashboard.ts
+++ b/app/services/admin/dashboard.ts
@@ -10,71 +10,68 @@ export const stats = {
 			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
 			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
-			const response = await axiosServer.get('/admin/stats/users/total', {
+			const response = await axiosServer.get('/admin/v2/stats/users', {
 				params,
 			});
-			;
-			return response.data;
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
 	},
 	getDailySignupCount: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
 		try {
-			const params: any = {};
+			const params: any = { period: 'daily' };
 			if (region) params.region = region;
 			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
 			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
-			const response = await axiosServer.get('/admin/stats/users/daily', {
+			const response = await axiosServer.get('/admin/v2/stats/users', {
 				params,
 			});
-			;
-			return response.data;
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
 	},
 	getWeeklySignupCount: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
 		try {
-			const params: any = {};
+			const params: any = { period: 'weekly' };
 			if (region) params.region = region;
 			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
 			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
-			const response = await axiosServer.get('/admin/stats/users/weekly', {
+			const response = await axiosServer.get('/admin/v2/stats/users', {
 				params,
 			});
-			;
-			return response.data;
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
 	},
 	getDailySignupTrend: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
 		try {
-			const params: any = {};
+			const params: any = { period: 'daily' };
 			if (region) params.region = region;
 			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
 			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
-			const response = await axiosServer.get('/admin/stats/users/trend/daily', {
+			const response = await axiosServer.get('/admin/v2/stats/users/trend', {
 				params,
 			});
-			return response.data;
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
 	},
 	getWeeklySignupTrend: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
 		try {
-			const params: any = {};
+			const params: any = { period: 'weekly' };
 			if (region) params.region = region;
 			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
 			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
-			const response = await axiosServer.get('/admin/stats/users/trend/weekly', { params });
-			return response.data;
+			const response = await axiosServer.get('/admin/v2/stats/users/trend', { params });
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -85,13 +82,13 @@ export const stats = {
 		useCluster?: boolean,
 	) => {
 		try {
-			const params: any = {};
+			const params: any = { period: 'monthly' };
 			if (region) params.region = region;
 			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
 			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
-			const response = await axiosServer.get('/admin/stats/users/trend/monthly', { params });
-			return response.data;
+			const response = await axiosServer.get('/admin/v2/stats/users/trend', { params });
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -105,30 +102,26 @@ export const stats = {
 		useCluster?: boolean,
 	) => {
 		try {
-			;
-			const requestData: any = {
-				startDate,
-				endDate,
+			const params: any = {
+				from: startDate,
+				to: endDate,
 			};
 
 			if (region) {
-				requestData.region = region;
+				params.region = region;
 			}
 
 			if (includeDeleted !== undefined) {
-				requestData.includeDeleted = includeDeleted;
+				params.includeDeleted = String(includeDeleted);
 			}
 
 			if (useCluster !== undefined) {
-				requestData.useCluster = useCluster;
+				params.useCluster = String(useCluster);
 			}
 
-			const response = await axiosServer.post('/admin/stats/users/custom-period', requestData);
+			const response = await axiosServer.get('/admin/v2/stats/users', { params });
 
-			;
-			;
-
-			return response.data;
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -142,33 +135,27 @@ export const stats = {
 		useCluster?: boolean,
 	) => {
 		try {
-			;
-			const requestData: any = {
-				startDate,
-				endDate,
+			const params: any = {
+				period: 'daily',
+				from: startDate,
+				to: endDate,
 			};
 
 			if (region) {
-				requestData.region = region;
+				params.region = region;
 			}
 
 			if (includeDeleted !== undefined) {
-				requestData.includeDeleted = includeDeleted;
+				params.includeDeleted = String(includeDeleted);
 			}
 
 			if (useCluster !== undefined) {
-				requestData.useCluster = useCluster;
+				params.useCluster = String(useCluster);
 			}
 
-			const response = await axiosServer.post(
-				'/admin/stats/users/trend/custom-period',
-				requestData,
-			);
+			const response = await axiosServer.get('/admin/v2/stats/users/trend', { params });
 
-			;
-			;
-
-			return response.data;
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -181,11 +168,10 @@ export const stats = {
 			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
 			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
-			const response = await axiosServer.get('/admin/stats/users/gender', {
+			const response = await axiosServer.get('/admin/v2/stats/users', {
 				params,
 			});
-			;
-			return response.data;
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -198,25 +184,9 @@ export const stats = {
 			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
 			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
-			const response = await axiosServer.get('/admin/stats/users/universities', { params });
-			;
-			;
+			const response = await axiosServer.get('/admin/v2/stats/users', { params });
 
-			if (response.data && response.data.universities && response.data.universities.length > 0) {
-				;
-				;
-
-				const firstUni = response.data.universities[0];
-				;
-				;
-				;
-				;
-				;
-				;
-				;
-			}
-
-			return response.data;
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -228,10 +198,10 @@ export const stats = {
 			if (region) params.region = region;
 			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
-			const response = await axiosServer.get('/admin/stats/withdrawals/total', {
+			const response = await axiosServer.get('/admin/v2/stats/withdrawals', {
 				params,
 			});
-			return response.data;
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -239,14 +209,14 @@ export const stats = {
 
 	getDailyWithdrawalCount: async (region?: string, useCluster?: boolean) => {
 		try {
-			const params: any = {};
+			const params: any = { period: 'daily' };
 			if (region) params.region = region;
 			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
-			const response = await axiosServer.get('/admin/stats/withdrawals/daily', {
+			const response = await axiosServer.get('/admin/v2/stats/withdrawals', {
 				params,
 			});
-			return response.data;
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -254,12 +224,12 @@ export const stats = {
 
 	getWeeklyWithdrawalCount: async (region?: string, useCluster?: boolean) => {
 		try {
-			const params: any = {};
+			const params: any = { period: 'weekly' };
 			if (region) params.region = region;
 			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
-			const response = await axiosServer.get('/admin/stats/withdrawals/weekly', { params });
-			return response.data;
+			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -267,12 +237,12 @@ export const stats = {
 
 	getMonthlyWithdrawalCount: async (region?: string, useCluster?: boolean) => {
 		try {
-			const params: any = {};
+			const params: any = { period: 'monthly' };
 			if (region) params.region = region;
 			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
-			const response = await axiosServer.get('/admin/stats/withdrawals/monthly', { params });
-			return response.data;
+			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -280,12 +250,10 @@ export const stats = {
 
 	getCustomPeriodWithdrawalCount: async (startDate: string, endDate: string) => {
 		try {
-			;
-			const response = await axiosServer.post('/admin/stats/withdrawals/custom-period', {
-				startDate,
-				endDate,
+			const response = await axiosServer.get('/admin/v2/stats/withdrawals', {
+				params: { from: startDate, to: endDate },
 			});
-			return response.data;
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -293,12 +261,12 @@ export const stats = {
 
 	getDailyWithdrawalTrend: async (region?: string, useCluster?: boolean) => {
 		try {
-			const params: any = {};
+			const params: any = { period: 'daily' };
 			if (region) params.region = region;
 			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
-			const response = await axiosServer.get('/admin/stats/withdrawals/trend/daily', { params });
-			return response.data;
+			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -306,12 +274,12 @@ export const stats = {
 
 	getWeeklyWithdrawalTrend: async (region?: string, useCluster?: boolean) => {
 		try {
-			const params: any = {};
+			const params: any = { period: 'weekly' };
 			if (region) params.region = region;
 			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
-			const response = await axiosServer.get('/admin/stats/withdrawals/trend/weekly', { params });
-			return response.data;
+			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -319,12 +287,12 @@ export const stats = {
 
 	getMonthlyWithdrawalTrend: async (region?: string, useCluster?: boolean) => {
 		try {
-			const params: any = {};
+			const params: any = { period: 'monthly' };
 			if (region) params.region = region;
 			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
-			const response = await axiosServer.get('/admin/stats/withdrawals/trend/monthly', { params });
-			return response.data;
+			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -332,16 +300,15 @@ export const stats = {
 
 	getCustomPeriodWithdrawalTrend: async (startDate: string, endDate: string, region?: string, useCluster?: boolean) => {
 		try {
-			;
-			const requestData: any = {
-				startDate,
-				endDate,
+			const params: any = {
+				from: startDate,
+				to: endDate,
 			};
-			if (region) requestData.region = region;
-			if (useCluster !== undefined) requestData.useCluster = useCluster;
+			if (region) params.region = region;
+			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
-			const response = await axiosServer.post('/admin/stats/withdrawals/trend/custom-period', requestData);
-			return response.data;
+			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -350,11 +317,11 @@ export const stats = {
 	getWithdrawalReasonStats: async (startDate?: string, endDate?: string) => {
 		try {
 			const params: any = {};
-			if (startDate) params.startDate = startDate;
-			if (endDate) params.endDate = endDate;
+			if (startDate) params.from = startDate;
+			if (endDate) params.to = endDate;
 
-			const response = await axiosServer.get('/admin/stats/withdrawals/reasons', { params });
-			return response.data;
+			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -362,8 +329,8 @@ export const stats = {
 
 	getChurnRate: async () => {
 		try {
-			const response = await axiosServer.get('/admin/stats/withdrawals/churn-rate');
-			return response.data;
+			const response = await axiosServer.get('/admin/v2/stats/withdrawals');
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}

--- a/app/services/admin/dashboard.ts
+++ b/app/services/admin/dashboard.ts
@@ -174,7 +174,7 @@ export const stats = {
 			const response = await axiosServer.get('/admin/v2/stats/users', {
 				params,
 			});
-			const raw = response.data.data;
+			const raw = response.data?.data ?? {};
 			const gender = raw.gender ?? {};
 			const maleCount = gender.male ?? 0;
 			const femaleCount = gender.female ?? 0;
@@ -202,7 +202,7 @@ export const stats = {
 			if (region) params.region = region;
 
 			const response = await axiosServer.get('/admin/v2/stats/users', { params });
-			const raw = response.data.data;
+			const raw = response.data?.data ?? {};
 			const totalCount = raw.totalUsers ?? 0;
 			const universities = (raw.universities ?? []).map((u: any) => ({
 				universityName: u.name,

--- a/app/services/admin/dashboard.ts
+++ b/app/services/admin/dashboard.ts
@@ -67,9 +67,11 @@ export const stats = {
 
 			const response = await axiosServer.get('/admin/v2/stats/users/trend', { params });
 			const raw = response.data.data;
+			const trendItems = Array.isArray(raw?.data) ? raw.data : [];
 			return {
 				...raw,
-				data: (raw.data || []).map((item: { date: string; count: number }) => {
+				data: trendItems.map((item: { date: string; count: number }) => {
+					if (!item?.date) return { weekStart: '', weekEnd: '', count: item?.count ?? 0, label: '' };
 					const parts = item.date.split('-');
 					const year = parseInt(parts[0], 10);
 					const week = parseInt(parts[1], 10);
@@ -99,12 +101,13 @@ export const stats = {
 
 			const response = await axiosServer.get('/admin/v2/stats/users/trend', { params });
 			const raw = response.data.data;
+			const trendItems = Array.isArray(raw?.data) ? raw.data : [];
 			return {
 				...raw,
-				data: (raw.data || []).map((item: { date: string; count: number }) => ({
-					month: item.date,
-					count: item.count,
-					label: item.date,
+				data: trendItems.map((item: { date: string; count: number }) => ({
+					month: item?.date ?? '',
+					count: item?.count ?? 0,
+					label: item?.date ?? '',
 				})),
 			};
 		} catch (error) {
@@ -287,7 +290,7 @@ export const stats = {
 
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
 			const raw = response.data.data;
-			const trend = raw.trend || raw.data || [];
+			const trend = Array.isArray(raw?.trend) ? raw.trend : Array.isArray(raw?.data) ? raw.data : [];
 			return {
 				...raw,
 				data: trend.map((item: { date: string; count: number }) => ({
@@ -307,10 +310,11 @@ export const stats = {
 
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
 			const raw = response.data.data;
-			const trend = raw.trend || raw.data || [];
+			const trend = Array.isArray(raw?.trend) ? raw.trend : Array.isArray(raw?.data) ? raw.data : [];
 			return {
 				...raw,
 				data: trend.map((item: { date: string; count: number }) => {
+					if (!item?.date) return { ...item, label: '' };
 					const parts = item.date.split('-');
 					const year = parseInt(parts[0], 10);
 					const week = parseInt(parts[1], 10);
@@ -338,7 +342,7 @@ export const stats = {
 
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
 			const raw = response.data.data;
-			const trend = raw.trend || raw.data || [];
+			const trend = Array.isArray(raw?.trend) ? raw.trend : Array.isArray(raw?.data) ? raw.data : [];
 			return {
 				...raw,
 				data: trend.map((item: { date: string; count: number }) => ({
@@ -361,7 +365,7 @@ export const stats = {
 
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
 			const raw = response.data.data;
-			const trend = raw.trend || raw.data || [];
+			const trend = Array.isArray(raw?.trend) ? raw.trend : Array.isArray(raw?.data) ? raw.data : [];
 			return {
 				...raw,
 				data: trend.map((item: { date: string; count: number }) => ({

--- a/app/services/admin/dashboard.ts
+++ b/app/services/admin/dashboard.ts
@@ -3,10 +3,11 @@ import { adminGet, adminPost } from '@/shared/lib/http/admin-fetch';
 import type { FormattedData } from './_shared';
 
 export const stats = {
-	getTotalUsersCount: async (region?: string) => {
+	getTotalUsersCount: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
 		try {
 			const params: any = {};
 			if (region) params.region = region;
+			if (includeDeleted !== undefined) params.includeDeleted = includeDeleted;
 
 			const response = await axiosServer.get('/admin/v2/stats/users', {
 				params,
@@ -16,10 +17,11 @@ export const stats = {
 			throw error;
 		}
 	},
-	getDailySignupCount: async (region?: string) => {
+	getDailySignupCount: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
 		try {
 			const params: any = { period: 'daily' };
 			if (region) params.region = region;
+			if (includeDeleted !== undefined) params.includeDeleted = includeDeleted;
 
 			const response = await axiosServer.get('/admin/v2/stats/users', {
 				params,
@@ -29,10 +31,11 @@ export const stats = {
 			throw error;
 		}
 	},
-	getWeeklySignupCount: async (region?: string) => {
+	getWeeklySignupCount: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
 		try {
 			const params: any = { period: 'weekly' };
 			if (region) params.region = region;
+			if (includeDeleted !== undefined) params.includeDeleted = includeDeleted;
 
 			const response = await axiosServer.get('/admin/v2/stats/users', {
 				params,
@@ -42,10 +45,11 @@ export const stats = {
 			throw error;
 		}
 	},
-	getDailySignupTrend: async (region?: string) => {
+	getDailySignupTrend: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
 		try {
 			const params: any = { period: 'daily' };
 			if (region) params.region = region;
+			if (includeDeleted !== undefined) params.includeDeleted = includeDeleted;
 
 			const response = await axiosServer.get('/admin/v2/stats/users/trend', {
 				params,
@@ -55,10 +59,11 @@ export const stats = {
 			throw error;
 		}
 	},
-	getWeeklySignupTrend: async (region?: string) => {
+	getWeeklySignupTrend: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
 		try {
 			const params: any = { period: 'weekly' };
 			if (region) params.region = region;
+			if (includeDeleted !== undefined) params.includeDeleted = includeDeleted;
 
 			const response = await axiosServer.get('/admin/v2/stats/users/trend', { params });
 			return response.data.data;
@@ -66,10 +71,11 @@ export const stats = {
 			throw error;
 		}
 	},
-	getMonthlySignupTrend: async (region?: string) => {
+	getMonthlySignupTrend: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
 		try {
 			const params: any = { period: 'monthly' };
 			if (region) params.region = region;
+			if (includeDeleted !== undefined) params.includeDeleted = includeDeleted;
 
 			const response = await axiosServer.get('/admin/v2/stats/users/trend', { params });
 			return response.data.data;
@@ -82,6 +88,8 @@ export const stats = {
 		startDate: string,
 		endDate: string,
 		region?: string,
+		includeDeleted?: boolean,
+		useCluster?: boolean,
 	) => {
 		try {
 			const params: any = {
@@ -105,6 +113,8 @@ export const stats = {
 		startDate: string,
 		endDate: string,
 		region?: string,
+		includeDeleted?: boolean,
+		useCluster?: boolean,
 	) => {
 		try {
 			const params: any = {
@@ -125,7 +135,7 @@ export const stats = {
 		}
 	},
 
-	getGenderStats: async (region?: string) => {
+	getGenderStats: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
 		try {
 			const params: any = {};
 			if (region) params.region = region;
@@ -139,7 +149,7 @@ export const stats = {
 		}
 	},
 
-	getUniversityStats: async (region?: string) => {
+	getUniversityStats: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
 		try {
 			const params: any = {};
 			if (region) params.region = region;
@@ -152,7 +162,7 @@ export const stats = {
 		}
 	},
 
-	getTotalWithdrawalsCount: async (region?: string) => {
+	getTotalWithdrawalsCount: async (region?: string, useCluster?: boolean) => {
 		try {
 			const params: any = {};
 			if (region) params.region = region;
@@ -166,7 +176,7 @@ export const stats = {
 		}
 	},
 
-	getDailyWithdrawalCount: async (region?: string) => {
+	getDailyWithdrawalCount: async (region?: string, useCluster?: boolean) => {
 		try {
 			const params: any = { period: 'daily' };
 			if (region) params.region = region;
@@ -180,7 +190,7 @@ export const stats = {
 		}
 	},
 
-	getWeeklyWithdrawalCount: async (region?: string) => {
+	getWeeklyWithdrawalCount: async (region?: string, useCluster?: boolean) => {
 		try {
 			const params: any = { period: 'weekly' };
 			if (region) params.region = region;
@@ -192,7 +202,7 @@ export const stats = {
 		}
 	},
 
-	getMonthlyWithdrawalCount: async (region?: string) => {
+	getMonthlyWithdrawalCount: async (region?: string, useCluster?: boolean) => {
 		try {
 			const params: any = { period: 'monthly' };
 			if (region) params.region = region;
@@ -215,7 +225,7 @@ export const stats = {
 		}
 	},
 
-	getDailyWithdrawalTrend: async (region?: string) => {
+	getDailyWithdrawalTrend: async (region?: string, useCluster?: boolean) => {
 		try {
 			const params: any = { period: 'daily' };
 			if (region) params.region = region;
@@ -227,7 +237,7 @@ export const stats = {
 		}
 	},
 
-	getWeeklyWithdrawalTrend: async (region?: string) => {
+	getWeeklyWithdrawalTrend: async (region?: string, useCluster?: boolean) => {
 		try {
 			const params: any = { period: 'weekly' };
 			if (region) params.region = region;
@@ -239,7 +249,7 @@ export const stats = {
 		}
 	},
 
-	getMonthlyWithdrawalTrend: async (region?: string) => {
+	getMonthlyWithdrawalTrend: async (region?: string, useCluster?: boolean) => {
 		try {
 			const params: any = { period: 'monthly' };
 			if (region) params.region = region;
@@ -251,7 +261,7 @@ export const stats = {
 		}
 	},
 
-	getCustomPeriodWithdrawalTrend: async (startDate: string, endDate: string, region?: string) => {
+	getCustomPeriodWithdrawalTrend: async (startDate: string, endDate: string, region?: string, useCluster?: boolean) => {
 		try {
 			const params: any = {
 				from: startDate,

--- a/app/services/admin/dashboard.ts
+++ b/app/services/admin/dashboard.ts
@@ -66,7 +66,27 @@ export const stats = {
 			if (includeDeleted !== undefined) params.includeDeleted = includeDeleted;
 
 			const response = await axiosServer.get('/admin/v2/stats/users/trend', { params });
-			return response.data.data;
+			const raw = response.data.data;
+			return {
+				...raw,
+				data: (raw.data || []).map((item: { date: string; count: number }) => {
+					const parts = item.date.split('-');
+					const year = parseInt(parts[0], 10);
+					const week = parseInt(parts[1], 10);
+					const jan4 = new Date(year, 0, 4);
+					const dayOfWeek = jan4.getDay() || 7;
+					const weekStart = new Date(jan4);
+					weekStart.setDate(jan4.getDate() - dayOfWeek + 1 + (week - 1) * 7);
+					const weekEnd = new Date(weekStart);
+					weekEnd.setDate(weekStart.getDate() + 6);
+					return {
+						weekStart: weekStart.toISOString().split('T')[0],
+						weekEnd: weekEnd.toISOString().split('T')[0],
+						count: item.count,
+						label: `${weekStart.toISOString().split('T')[0]} ~ ${weekEnd.toISOString().split('T')[0]}`,
+					};
+				}),
+			};
 		} catch (error) {
 			throw error;
 		}
@@ -78,7 +98,15 @@ export const stats = {
 			if (includeDeleted !== undefined) params.includeDeleted = includeDeleted;
 
 			const response = await axiosServer.get('/admin/v2/stats/users/trend', { params });
-			return response.data.data;
+			const raw = response.data.data;
+			return {
+				...raw,
+				data: (raw.data || []).map((item: { date: string; count: number }) => ({
+					month: item.date,
+					count: item.count,
+					label: item.date,
+				})),
+			};
 		} catch (error) {
 			throw error;
 		}
@@ -143,7 +171,23 @@ export const stats = {
 			const response = await axiosServer.get('/admin/v2/stats/users', {
 				params,
 			});
-			return response.data.data;
+			const raw = response.data.data;
+			const gender = raw.gender ?? {};
+			const maleCount = gender.male ?? 0;
+			const femaleCount = gender.female ?? 0;
+			const totalCount = raw.totalUsers ?? 0;
+			const malePercentage = gender.maleRatio ?? 0;
+			const femalePercentage = gender.femaleRatio ?? 0;
+			const maleRatioInt = Math.round(malePercentage);
+			const femaleRatioInt = Math.round(femalePercentage);
+			return {
+				maleCount,
+				femaleCount,
+				totalCount,
+				malePercentage,
+				femalePercentage,
+				genderRatio: `${maleRatioInt}:${femaleRatioInt}`,
+			};
 		} catch (error) {
 			throw error;
 		}
@@ -155,8 +199,19 @@ export const stats = {
 			if (region) params.region = region;
 
 			const response = await axiosServer.get('/admin/v2/stats/users', { params });
-
-			return response.data.data;
+			const raw = response.data.data;
+			const totalCount = raw.totalUsers ?? 0;
+			const universities = (raw.universities ?? []).map((u: any) => ({
+				universityName: u.name,
+				totalCount: u.totalUsers ?? 0,
+				maleCount: u.maleUsers ?? 0,
+				femaleCount: u.femaleUsers ?? 0,
+				percentage: u.ratio ?? 0,
+				genderRatio: (u.maleUsers ?? 0) > 0 || (u.femaleUsers ?? 0) > 0
+					? `${u.maleUsers ?? 0}:${u.femaleUsers ?? 0}`
+					: '-',
+			}));
+			return { universities, totalCount };
 		} catch (error) {
 			throw error;
 		}
@@ -231,7 +286,15 @@ export const stats = {
 			if (region) params.region = region;
 
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
-			return response.data.data;
+			const raw = response.data.data;
+			const trend = raw.trend || raw.data || [];
+			return {
+				...raw,
+				data: trend.map((item: { date: string; count: number }) => ({
+					...item,
+					label: item.date,
+				})),
+			};
 		} catch (error) {
 			throw error;
 		}
@@ -243,7 +306,26 @@ export const stats = {
 			if (region) params.region = region;
 
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
-			return response.data.data;
+			const raw = response.data.data;
+			const trend = raw.trend || raw.data || [];
+			return {
+				...raw,
+				data: trend.map((item: { date: string; count: number }) => {
+					const parts = item.date.split('-');
+					const year = parseInt(parts[0], 10);
+					const week = parseInt(parts[1], 10);
+					const jan4 = new Date(year, 0, 4);
+					const dayOfWeek = jan4.getDay() || 7;
+					const weekStart = new Date(jan4);
+					weekStart.setDate(jan4.getDate() - dayOfWeek + 1 + (week - 1) * 7);
+					const weekEnd = new Date(weekStart);
+					weekEnd.setDate(weekStart.getDate() + 6);
+					return {
+						...item,
+						label: `${weekStart.toISOString().split('T')[0]} ~ ${weekEnd.toISOString().split('T')[0]}`,
+					};
+				}),
+			};
 		} catch (error) {
 			throw error;
 		}
@@ -255,7 +337,15 @@ export const stats = {
 			if (region) params.region = region;
 
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
-			return response.data.data;
+			const raw = response.data.data;
+			const trend = raw.trend || raw.data || [];
+			return {
+				...raw,
+				data: trend.map((item: { date: string; count: number }) => ({
+					...item,
+					label: item.date,
+				})),
+			};
 		} catch (error) {
 			throw error;
 		}
@@ -270,7 +360,15 @@ export const stats = {
 			if (region) params.region = region;
 
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
-			return response.data.data;
+			const raw = response.data.data;
+			const trend = raw.trend || raw.data || [];
+			return {
+				...raw,
+				data: trend.map((item: { date: string; count: number }) => ({
+					...item,
+					label: item.date,
+				})),
+			};
 		} catch (error) {
 			throw error;
 		}
@@ -292,7 +390,14 @@ export const stats = {
 	getChurnRate: async () => {
 		try {
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals');
-			return response.data.data;
+			const raw = response.data.data;
+			const cr = raw.churnRate ?? {};
+			return {
+				...raw,
+				dailyChurnRate: cr.daily ?? 0,
+				weeklyChurnRate: cr.weekly ?? 0,
+				monthlyChurnRate: cr.monthly ?? 0,
+			};
 		} catch (error) {
 			throw error;
 		}

--- a/app/services/admin/dashboard.ts
+++ b/app/services/admin/dashboard.ts
@@ -3,12 +3,10 @@ import { adminGet, adminPost } from '@/shared/lib/http/admin-fetch';
 import type { FormattedData } from './_shared';
 
 export const stats = {
-	getTotalUsersCount: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
+	getTotalUsersCount: async (region?: string) => {
 		try {
 			const params: any = {};
 			if (region) params.region = region;
-			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
-			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
 			const response = await axiosServer.get('/admin/v2/stats/users', {
 				params,
@@ -18,12 +16,10 @@ export const stats = {
 			throw error;
 		}
 	},
-	getDailySignupCount: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
+	getDailySignupCount: async (region?: string) => {
 		try {
 			const params: any = { period: 'daily' };
 			if (region) params.region = region;
-			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
-			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
 			const response = await axiosServer.get('/admin/v2/stats/users', {
 				params,
@@ -33,12 +29,10 @@ export const stats = {
 			throw error;
 		}
 	},
-	getWeeklySignupCount: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
+	getWeeklySignupCount: async (region?: string) => {
 		try {
 			const params: any = { period: 'weekly' };
 			if (region) params.region = region;
-			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
-			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
 			const response = await axiosServer.get('/admin/v2/stats/users', {
 				params,
@@ -48,12 +42,10 @@ export const stats = {
 			throw error;
 		}
 	},
-	getDailySignupTrend: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
+	getDailySignupTrend: async (region?: string) => {
 		try {
 			const params: any = { period: 'daily' };
 			if (region) params.region = region;
-			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
-			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
 			const response = await axiosServer.get('/admin/v2/stats/users/trend', {
 				params,
@@ -63,12 +55,10 @@ export const stats = {
 			throw error;
 		}
 	},
-	getWeeklySignupTrend: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
+	getWeeklySignupTrend: async (region?: string) => {
 		try {
 			const params: any = { period: 'weekly' };
 			if (region) params.region = region;
-			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
-			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
 			const response = await axiosServer.get('/admin/v2/stats/users/trend', { params });
 			return response.data.data;
@@ -76,16 +66,10 @@ export const stats = {
 			throw error;
 		}
 	},
-	getMonthlySignupTrend: async (
-		region?: string,
-		includeDeleted?: boolean,
-		useCluster?: boolean,
-	) => {
+	getMonthlySignupTrend: async (region?: string) => {
 		try {
 			const params: any = { period: 'monthly' };
 			if (region) params.region = region;
-			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
-			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
 			const response = await axiosServer.get('/admin/v2/stats/users/trend', { params });
 			return response.data.data;
@@ -98,8 +82,6 @@ export const stats = {
 		startDate: string,
 		endDate: string,
 		region?: string,
-		includeDeleted?: boolean,
-		useCluster?: boolean,
 	) => {
 		try {
 			const params: any = {
@@ -109,14 +91,6 @@ export const stats = {
 
 			if (region) {
 				params.region = region;
-			}
-
-			if (includeDeleted !== undefined) {
-				params.includeDeleted = String(includeDeleted);
-			}
-
-			if (useCluster !== undefined) {
-				params.useCluster = String(useCluster);
 			}
 
 			const response = await axiosServer.get('/admin/v2/stats/users', { params });
@@ -131,8 +105,6 @@ export const stats = {
 		startDate: string,
 		endDate: string,
 		region?: string,
-		includeDeleted?: boolean,
-		useCluster?: boolean,
 	) => {
 		try {
 			const params: any = {
@@ -145,14 +117,6 @@ export const stats = {
 				params.region = region;
 			}
 
-			if (includeDeleted !== undefined) {
-				params.includeDeleted = String(includeDeleted);
-			}
-
-			if (useCluster !== undefined) {
-				params.useCluster = String(useCluster);
-			}
-
 			const response = await axiosServer.get('/admin/v2/stats/users/trend', { params });
 
 			return response.data.data;
@@ -161,12 +125,10 @@ export const stats = {
 		}
 	},
 
-	getGenderStats: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
+	getGenderStats: async (region?: string) => {
 		try {
 			const params: any = {};
 			if (region) params.region = region;
-			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
-			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
 			const response = await axiosServer.get('/admin/v2/stats/users', {
 				params,
@@ -177,12 +139,10 @@ export const stats = {
 		}
 	},
 
-	getUniversityStats: async (region?: string, includeDeleted?: boolean, useCluster?: boolean) => {
+	getUniversityStats: async (region?: string) => {
 		try {
 			const params: any = {};
 			if (region) params.region = region;
-			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
-			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
 			const response = await axiosServer.get('/admin/v2/stats/users', { params });
 
@@ -192,11 +152,10 @@ export const stats = {
 		}
 	},
 
-	getTotalWithdrawalsCount: async (region?: string, useCluster?: boolean) => {
+	getTotalWithdrawalsCount: async (region?: string) => {
 		try {
 			const params: any = {};
 			if (region) params.region = region;
-			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals', {
 				params,
@@ -207,11 +166,10 @@ export const stats = {
 		}
 	},
 
-	getDailyWithdrawalCount: async (region?: string, useCluster?: boolean) => {
+	getDailyWithdrawalCount: async (region?: string) => {
 		try {
 			const params: any = { period: 'daily' };
 			if (region) params.region = region;
-			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals', {
 				params,
@@ -222,11 +180,10 @@ export const stats = {
 		}
 	},
 
-	getWeeklyWithdrawalCount: async (region?: string, useCluster?: boolean) => {
+	getWeeklyWithdrawalCount: async (region?: string) => {
 		try {
 			const params: any = { period: 'weekly' };
 			if (region) params.region = region;
-			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
 			return response.data.data;
@@ -235,11 +192,10 @@ export const stats = {
 		}
 	},
 
-	getMonthlyWithdrawalCount: async (region?: string, useCluster?: boolean) => {
+	getMonthlyWithdrawalCount: async (region?: string) => {
 		try {
 			const params: any = { period: 'monthly' };
 			if (region) params.region = region;
-			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
 			return response.data.data;
@@ -259,11 +215,10 @@ export const stats = {
 		}
 	},
 
-	getDailyWithdrawalTrend: async (region?: string, useCluster?: boolean) => {
+	getDailyWithdrawalTrend: async (region?: string) => {
 		try {
 			const params: any = { period: 'daily' };
 			if (region) params.region = region;
-			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
 			return response.data.data;
@@ -272,11 +227,10 @@ export const stats = {
 		}
 	},
 
-	getWeeklyWithdrawalTrend: async (region?: string, useCluster?: boolean) => {
+	getWeeklyWithdrawalTrend: async (region?: string) => {
 		try {
 			const params: any = { period: 'weekly' };
 			if (region) params.region = region;
-			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
 			return response.data.data;
@@ -285,11 +239,10 @@ export const stats = {
 		}
 	},
 
-	getMonthlyWithdrawalTrend: async (region?: string, useCluster?: boolean) => {
+	getMonthlyWithdrawalTrend: async (region?: string) => {
 		try {
 			const params: any = { period: 'monthly' };
 			if (region) params.region = region;
-			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
 			return response.data.data;
@@ -298,14 +251,13 @@ export const stats = {
 		}
 	},
 
-	getCustomPeriodWithdrawalTrend: async (startDate: string, endDate: string, region?: string, useCluster?: boolean) => {
+	getCustomPeriodWithdrawalTrend: async (startDate: string, endDate: string, region?: string) => {
 		try {
 			const params: any = {
 				from: startDate,
 				to: endDate,
 			};
 			if (region) params.region = region;
-			if (useCluster !== undefined) params.useCluster = String(useCluster);
 
 			const response = await axiosServer.get('/admin/v2/stats/withdrawals', { params });
 			return response.data.data;

--- a/app/services/admin/messaging.ts
+++ b/app/services/admin/messaging.ts
@@ -77,9 +77,9 @@ export const aiChat = {
 				}
 			});
 
-			const response = await axiosServer.get(`/admin/ai-chat/sessions?${queryParams.toString()}`);
+			const response = await axiosServer.get(`/admin/v2/ai-chat/sessions?${queryParams.toString()}`);
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -88,9 +88,9 @@ export const aiChat = {
 	// AI 채팅 메시지 상세 조회
 	getMessages: async (sessionId: string) => {
 		try {
-			const response = await axiosServer.get(`/admin/ai-chat/messages?sessionId=${sessionId}`);
+			const response = await axiosServer.get(`/admin/v2/ai-chat/sessions/${sessionId}/messages`);
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}

--- a/app/services/admin/messaging.ts
+++ b/app/services/admin/messaging.ts
@@ -90,7 +90,12 @@ export const aiChat = {
 		try {
 			const response = await axiosServer.get(`/admin/v2/ai-chat/sessions/${sessionId}/messages`);
 			;
-			return response.data.data;
+			const raw = response.data.data;
+			return {
+				messages: raw.items || [],
+				totalCount: raw.totalCount || 0,
+				session: null,
+			};
 		} catch (error) {
 			throw error;
 		}

--- a/app/services/admin/messaging.ts
+++ b/app/services/admin/messaging.ts
@@ -90,7 +90,7 @@ export const aiChat = {
 		try {
 			const response = await axiosServer.get(`/admin/v2/ai-chat/sessions/${sessionId}/messages`);
 			;
-			const raw = response.data.data;
+			const raw = response.data?.data ?? {};
 			return {
 				messages: raw.items || [],
 				totalCount: raw.totalCount || 0,

--- a/app/services/admin/moderation.ts
+++ b/app/services/admin/moderation.ts
@@ -62,6 +62,7 @@ export interface ReviewHistoryResponse {
 		page: number;
 		limit: number;
 		total: number;
+		totalPages: number;
 		hasMore: boolean;
 	};
 }
@@ -210,7 +211,7 @@ export const userReview = {
 			});
 
 			;
-			return response.data.data;
+			return { data: response.data.data, meta: response.data.meta };
 		} catch (error: any) {
 			throw error;
 		}
@@ -337,6 +338,7 @@ export const userReview = {
 					page: meta.page,
 					limit: meta.limit,
 					total: meta.total,
+					totalPages: meta.totalPages,
 					hasMore: meta.page < meta.totalPages,
 				},
 			};
@@ -354,7 +356,7 @@ export const profileImages = {
 			const response = await axiosServer.get('/admin/v2/profile-review/pending');
 
 			;
-			return response.data.data;
+			return { data: response.data.data, meta: response.data.meta };
 		} catch (error: any) {
 			throw error;
 		}

--- a/app/services/admin/moderation.ts
+++ b/app/services/admin/moderation.ts
@@ -92,13 +92,13 @@ export const reports = {
 				queryParams.append('status', status === 'pending' ? 'pending' : 'processed');
 			}
 
-			const endpoint = `/admin/community/reports?${queryParams.toString()}`;
+			const endpoint = `/admin/v2/reports?${queryParams.toString()}`;
 			;
 
 			const response = await axiosServer.get(endpoint);
 			;
 
-			const transformedItems = (response.data.items || []).map((item: any) => ({
+			const transformedItems = (response.data.data || []).map((item: any) => ({
 				id: item.id,
 				reporter: {
 					id: item.reporter?.id || item.reporterId,
@@ -128,7 +128,7 @@ export const reports = {
 
 			return {
 				items: transformedItems,
-				meta: response.data.meta,
+				meta: response.data.meta,  // v2: meta lives at response.data.meta
 			};
 		} catch (error: any) {
 			throw error;
@@ -138,9 +138,9 @@ export const reports = {
 	getProfileReportDetail: async (reportId: string) => {
 		try {
 			const response = await axiosServer.get(
-				`/admin/community/reports/profiles/${reportId}/detail`,
+				`/admin/v2/reports/${reportId}`,
 			);
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -153,10 +153,10 @@ export const reports = {
 	) => {
 		try {
 			const response = await axiosServer.patch(
-				`/admin/community/reports/profiles/${reportId}/status`,
+				`/admin/v2/reports/${reportId}/status`,
 				{ status, adminMemo },
 			);
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -205,12 +205,12 @@ export const userReview = {
 				params.excludeUserIds = excludeUserIds.join(',');
 			}
 
-			const response = await axiosServer.get('/admin/profile-images/pending', {
+			const response = await axiosServer.get('/admin/v2/profile-review/pending', {
 				params,
 			});
 
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -220,10 +220,10 @@ export const userReview = {
 		try {
 			;
 
-			const response = await axiosServer.get(`/admin/user-review/${userId}`);
+			const response = await axiosServer.get(`/admin/v2/profile-review/users/${userId}`);
 
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -233,10 +233,10 @@ export const userReview = {
 		try {
 			;
 
-			const response = await axiosServer.post(`/admin/profile-images/users/${userId}/approve`);
+			const response = await axiosServer.post(`/admin/v2/profile-review/users/${userId}/approve-profile`);
 
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -246,13 +246,13 @@ export const userReview = {
 		try {
 			;
 
-			const response = await axiosServer.post(`/admin/user-review/${userId}/reject`, {
+			const response = await axiosServer.post(`/admin/v2/profile-review/users/${userId}/reject-profile`, {
 				category,
 				reason,
 			});
 
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -294,13 +294,13 @@ export const userReview = {
 			;
 
 			const response = await axiosServer.patch(
-				`/admin/profiles/${userId}/rank`,
+				`/admin/v2/profile-review/users/${userId}/rank`,
 				{ rank },
 				{ params: { emitEvent } },
 			);
 
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -325,11 +325,21 @@ export const userReview = {
 			if (filters.universityId) params.universityId = filters.universityId;
 			if (filters.reviewedBy) params.reviewedBy = filters.reviewedBy;
 
-			const response = await axiosServer.get('/admin/profile-images/review-history', {
+			const response = await axiosServer.get('/admin/v2/profile-review/history', {
 				params,
 			});
 
-			return response.data;
+			const data = response.data.data;
+			const meta = response.data.meta;
+			return {
+				items: data,
+				pagination: {
+					page: meta.page,
+					limit: meta.limit,
+					total: meta.total,
+					hasMore: meta.page < meta.totalPages,
+				},
+			};
 		} catch (error: any) {
 			throw error;
 		}
@@ -341,10 +351,10 @@ export const profileImages = {
 		try {
 			;
 
-			const response = await axiosServer.get('/admin/profile-images/pending');
+			const response = await axiosServer.get('/admin/v2/profile-review/pending');
 
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -354,10 +364,10 @@ export const profileImages = {
 		try {
 			;
 
-			const response = await axiosServer.post(`/admin/profile-images/users/${userId}/approve`);
+			const response = await axiosServer.post(`/admin/v2/profile-review/users/${userId}/approve-profile`);
 
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -367,12 +377,12 @@ export const profileImages = {
 		try {
 			;
 
-			const response = await axiosServer.post(`/admin/profile-images/users/${userId}/reject`, {
+			const response = await axiosServer.post(`/admin/v2/profile-review/users/${userId}/reject-profile`, {
 				rejectionReason,
 			});
 
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -382,10 +392,12 @@ export const profileImages = {
 		try {
 			;
 
-			const response = await axiosServer.post(`/admin/profile-images/${imageId}/approve`);
+			const response = await axiosServer.post(`/admin/v2/profile-review/images/${imageId}/action`, {
+				action: 'approve',
+			});
 
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -395,12 +407,13 @@ export const profileImages = {
 		try {
 			;
 
-			const response = await axiosServer.post(`/admin/profile-images/${imageId}/reject`, {
-				rejectionReason,
+			const response = await axiosServer.post(`/admin/v2/profile-review/images/${imageId}/action`, {
+				action: 'reject',
+				reason: rejectionReason,
 			});
 
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -411,11 +424,12 @@ export const profileImages = {
 			;
 
 			const response = await axiosServer.post(
-				`/admin/profile-images/users/${userId}/set-main/${imageId}`,
+				`/admin/v2/profile-review/images/${imageId}/action`,
+				{ action: 'setMain' },
 			);
 
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}

--- a/app/services/admin/moderation.ts
+++ b/app/services/admin/moderation.ts
@@ -330,8 +330,25 @@ export const userReview = {
 				params,
 			});
 
-			const data = response.data.data;
+			const rawItems = response.data.data;
 			const meta = response.data.meta;
+			const data = (rawItems || []).map((item: any) => ({
+				imageId: item.imageId,
+				imageUrl: item.url,
+				slotIndex: item.slotIndex ?? 0,
+				isMain: item.isMain ?? false,
+				reviewStatus: item.reviewStatus,
+				reviewType: item.reviewType ?? null,
+				reviewedBy: item.reviewerName ?? item.reviewedBy ?? null,
+				reviewedAt: item.reviewedAt,
+				rejectionReason: item.reason,
+				user: {
+					userId: item.userId,
+					name: item.userName,
+					gender: item.gender,
+					age: item.age,
+				},
+			}));
 			return {
 				items: data,
 				pagination: {

--- a/app/services/admin/users.ts
+++ b/app/services/admin/users.ts
@@ -66,7 +66,7 @@ export const userAppearance = {
 				const response = await axiosServer.get(url);
 				;
 				;
-				return response.data.data;
+				return { data: response.data.data, meta: response.data.meta };
 			} catch (error: any) {
 				throw error;
 			}
@@ -88,7 +88,7 @@ export const userAppearance = {
 
 			;
 
-			return response.data.data;
+			return { data: response.data.data, meta: response.data.meta };
 		} catch (error) {
 			throw error;
 		}
@@ -854,7 +854,7 @@ export const userAppearance = {
 			const response = await axiosServer.get(`/admin/v2/users?filter=verified&${queryParams.toString()}`);
 
 			;
-			return response.data.data;
+			return { data: response.data.data, meta: response.data.meta };
 		} catch (error: any) {
 			throw error;
 		}
@@ -926,7 +926,7 @@ export const userAppearance = {
 			const response = await axiosServer.get(`/admin/v2/users?filter=blacklisted&${params.toString()}`);
 
 			;
-			return response.data.data;
+			return { data: response.data.data, meta: response.data.meta };
 		} catch (error: any) {
 			throw error;
 		}
@@ -992,7 +992,7 @@ export const userAppearance = {
 			});
 
 			;
-			return response.data.data;
+			return { data: response.data.data, meta: response.data.meta };
 		} catch (error: any) {
 			throw error;
 		}
@@ -1011,7 +1011,7 @@ export const userAppearance = {
 			});
 
 			;
-			return response.data.data;
+			return { data: response.data.data, meta: response.data.meta };
 		} catch (error: any) {
 			throw error;
 		}
@@ -1035,7 +1035,7 @@ export const userAppearance = {
 			});
 
 			;
-			return response.data.data;
+			return { data: response.data.data, meta: response.data.meta };
 		} catch (error: any) {
 			throw error;
 		}

--- a/app/services/admin/users.ts
+++ b/app/services/admin/users.ts
@@ -56,7 +56,9 @@ export const userAppearance = {
 				queryParams.append('includeDeleted', params.includeDeleted.toString());
 			if (params.userStatus) queryParams.append('userStatus', params.userStatus);
 
-			const url = `/admin/users/appearance?${queryParams.toString()}`;
+			queryParams.append('filter', 'all');
+
+			const url = `/admin/v2/users?${queryParams.toString()}`;
 			;
 			;
 
@@ -64,7 +66,7 @@ export const userAppearance = {
 				const response = await axiosServer.get(url);
 				;
 				;
-				return response.data;
+				return response.data.data;
 			} catch (error: any) {
 				throw error;
 			}
@@ -81,12 +83,12 @@ export const userAppearance = {
 			if (region) params.append('region', region);
 
 			const response = await axiosServer.get(
-				`/admin/users/appearance/unclassified?${params.toString()}`,
+				`/admin/v2/users?filter=ungraded&${params.toString()}`,
 			);
 
 			;
 
-			return response.data;
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -104,9 +106,9 @@ export const userAppearance = {
 		}
 
 		try {
-			const response = await axiosServer.patch(`/admin/users/appearance/${userId}`, { grade });
+			const response = await axiosServer.patch(`/admin/v2/users/${userId}/appearance`, { grade });
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -139,11 +141,11 @@ export const userAppearance = {
 		;
 
 		try {
-			const response = await axiosServer.patch('/admin/users/appearance/bulk', {
+			const response = await axiosServer.patch('/admin/v2/users/appearance/bulk', {
 				userIds,
 				grade,
 			});
-			return response.data;
+			return response.data.data;
 		} catch (error) {
 			throw error;
 		}
@@ -153,13 +155,13 @@ export const userAppearance = {
 		try {
 			;
 
-			const endpoint = `/admin/user-review/${userId}`;
+			const endpoint = `/admin/v2/users/${userId}`;
 			;
 
 			const response = await axiosServer.get(endpoint);
 			;
 
-			const data = response.data;
+			const data = response.data.data;
 
 			if (
 				data.profileImageUrls &&
@@ -849,10 +851,10 @@ export const userAppearance = {
 			if (params.name) queryParams.append('name', params.name);
 			if (params.university) queryParams.append('university', params.university);
 
-			const response = await axiosServer.get(`/admin/users/verified?${queryParams.toString()}`);
+			const response = await axiosServer.get(`/admin/v2/users?filter=verified&${queryParams.toString()}`);
 
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -921,10 +923,10 @@ export const userAppearance = {
 			const params = new URLSearchParams();
 			if (region) params.append('region', region);
 
-			const response = await axiosServer.get(`/admin/users/blacklist?${params.toString()}`);
+			const response = await axiosServer.get(`/admin/v2/users?filter=blacklisted&${params.toString()}`);
 
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -985,12 +987,12 @@ export const userAppearance = {
 			if (region) params.region = region;
 			if (name) params.name = name;
 
-			const response = await axiosServer.get('/admin/users/approval/reapply', {
-				params,
+			const response = await axiosServer.get('/admin/v2/users', {
+				params: { filter: 'resubmission', ...params },
 			});
 
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -1004,12 +1006,12 @@ export const userAppearance = {
 			if (region) params.region = region;
 			if (name) params.name = name;
 
-			const response = await axiosServer.get('/admin/users/approval/pending', {
-				params,
+			const response = await axiosServer.get('/admin/v2/users', {
+				params: { filter: 'pending', ...params },
 			});
 
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}
@@ -1028,12 +1030,12 @@ export const userAppearance = {
 			if (region) params.region = region;
 			if (name) params.name = name;
 
-			const response = await axiosServer.get('/admin/users/approval/rejected', {
-				params,
+			const response = await axiosServer.get('/admin/v2/users', {
+				params: { filter: 'rejected', ...params },
 			});
 
 			;
-			return response.data;
+			return response.data.data;
 		} catch (error: any) {
 			throw error;
 		}

--- a/app/services/admin/users.ts
+++ b/app/services/admin/users.ts
@@ -44,7 +44,7 @@ export const userAppearance = {
 			if (params.universityName) queryParams.append('universityName', params.universityName);
 			if (params.minAge) queryParams.append('minAge', params.minAge.toString());
 			if (params.maxAge) queryParams.append('maxAge', params.maxAge.toString());
-			if (params.searchTerm) queryParams.append('searchTerm', params.searchTerm);
+			if (params.searchTerm) queryParams.append('search', params.searchTerm);
 			if (params.region) queryParams.append('region', params.region);
 			if (params.useCluster !== undefined)
 				queryParams.append('useCluster', params.useCluster.toString());

--- a/app/services/chat.ts
+++ b/app/services/chat.ts
@@ -113,7 +113,7 @@ export interface ChatCsvExportParams {
 class ChatService {
   async getChatRooms(params: ChatRoomsParams): Promise<ChatRoomsResponse> {
     try {
-      const response = await axiosServer.get<ChatRoomsResponse>('/admin/chat/rooms', {
+      const response = await axiosServer.get<{ data: ChatRoomsResponse; meta: unknown }>('/admin/v2/chat/rooms', {
         params: {
           startDate: params.startDate,
           endDate: params.endDate,
@@ -123,7 +123,7 @@ class ChatService {
           limit: params.limit || 20
         }
       });
-      return response.data;
+      return response.data.data;
     } catch (error: any) {
       console.error('채팅방 목록 조회 실패:', error);
       throw new Error(error.response?.data?.message || '채팅방 목록을 불러오는데 실패했습니다.');
@@ -132,12 +132,15 @@ class ChatService {
 
   async getChatMessages(params: ChatMessagesParams): Promise<ChatMessagesResponse> {
     try {
-      const response = await axiosServer.get<ChatMessagesResponse>('/admin/chat/messages', {
-        params: {
-          chatRoomId: params.chatRoomId,
+      const response = await axiosServer.get<{ data: ChatMessagesResponse }>(
+        `/admin/v2/chat/rooms/${params.chatRoomId}/messages`,
+        {
+          params: {
+            limit: params.limit || 50,
+          }
         }
-      });
-      return response.data;
+      );
+      return response.data.data;
     } catch (error: any) {
       console.error('채팅 메시지 조회 실패:', error);
       throw new Error(error.response?.data?.message || '채팅 메시지를 불러오는데 실패했습니다.');
@@ -146,14 +149,14 @@ class ChatService {
 
   async getChatStats(params: ChatStatsParams = {}): Promise<ChatStatsResponse> {
     try {
-      const response = await axiosServer.get<ChatStatsResponse>('/admin/chat/stats', {
+      const response = await axiosServer.get<{ data: ChatStatsResponse }>('/admin/v2/chat/stats', {
         params: {
           startDate: params.startDate,
           endDate: params.endDate,
           preset: params.preset,
         }
       });
-      return response.data;
+      return response.data.data;
     } catch (error: any) {
       console.error('채팅 통계 조회 실패:', error);
       throw new Error(error.response?.data?.message || '채팅 통계를 불러오는데 실패했습니다.');
@@ -162,7 +165,7 @@ class ChatService {
 
   async exportChatsToCsv(params: ChatCsvExportParams = {}): Promise<void> {
     try {
-      const response = await axiosServer.get('/admin/chat/export/csv', {
+      const response = await axiosServer.get('/admin/v2/chat/export', {
         params: {
           startDate: params.startDate,
           endDate: params.endDate,

--- a/components/admin/appearance/ApprovalManagementPanel.tsx
+++ b/components/admin/appearance/ApprovalManagementPanel.tsx
@@ -246,33 +246,33 @@ const ApprovalManagementPanel: React.FC = () => {
         activeTab !== 2 ? AdminService.userAppearance.getReapplyUsers(1, 10, regionParam, nameSearch || undefined) : null
       ]);
 
-      const users = currentResponse.items || [];
+      const users = currentResponse.data || [];
       const currentMeta = currentResponse.meta || {};
 
       // 현재 탭 데이터 설정
       if (activeTab === 0) {
         setPendingUsers(users);
-        setPendingCount(currentMeta.totalItems || users.length);
+        setPendingCount(currentMeta.total || users.length);
       } else if (activeTab === 1) {
         setRejectedUsers(users);
-        setRejectedCount(currentMeta.totalItems || users.length);
+        setRejectedCount(currentMeta.total || users.length);
       } else {
         setReapplyUsers(users);
-        setReapplyCount(currentMeta.totalItems || users.length);
+        setReapplyCount(currentMeta.total || users.length);
       }
 
       // 다른 탭들의 카운트 설정
       if (pendingResponse && activeTab !== 0) {
-        setPendingCount(pendingResponse.meta?.totalItems || 0);
+        setPendingCount(pendingResponse.meta?.total || 0);
       }
       if (rejectedResponse && activeTab !== 1) {
-        setRejectedCount(rejectedResponse.meta?.totalItems || 0);
+        setRejectedCount(rejectedResponse.meta?.total || 0);
       }
       if (reapplyResponse && activeTab !== 2) {
-        setReapplyCount(reapplyResponse.meta?.totalItems || 0);
+        setReapplyCount(reapplyResponse.meta?.total || 0);
       }
 
-      setTotalPages(currentMeta.totalPages || Math.ceil((currentMeta.totalItems || users.length) / limit));
+      setTotalPages(currentMeta.totalPages || Math.ceil((currentMeta.total || users.length) / limit));
     } catch (err: any) {
       console.error('승인 대기 사용자 조회 오류:', err);
       setError('사용자 목록을 불러오는 중 오류가 발생했습니다.');

--- a/components/admin/appearance/BlacklistUsersPanel.tsx
+++ b/components/admin/appearance/BlacklistUsersPanel.tsx
@@ -69,8 +69,8 @@ const BlacklistUsersPanel: React.FC = () => {
       setLoading(true);
       setError(null);
 
-      const response: BlacklistUsersResponse = await AdminService.userAppearance.getBlacklistUsers(getRegionParam());
-      setUsers(response.users || []);
+      const response = await AdminService.userAppearance.getBlacklistUsers(getRegionParam());
+      setUsers(response.data || []);
     } catch (err: any) {
       console.error('블랙리스트 사용자 목록 조회 중 오류:', err);
       setError(err.message ?? '블랙리스트 사용자 목록을 불러오는 중 오류가 발생했습니다.');

--- a/components/admin/appearance/ProfileImageApprovalPanel.tsx
+++ b/components/admin/appearance/ProfileImageApprovalPanel.tsx
@@ -100,7 +100,7 @@ const ProfileImageApprovalPanel: React.FC = () => {
       setError(null);
       
       const response = await AdminService.profileImages.getPendingProfileImages();
-      setPendingUsers(response || []);
+      setPendingUsers(response.data || []);
     } catch (error: any) {
       console.error('심사 대기 중인 프로필 이미지 목록 조회 오류:', error);
       setError(error.message || '데이터를 불러오는 중 오류가 발생했습니다.');

--- a/components/admin/appearance/UnclassifiedUsersPanel.tsx
+++ b/components/admin/appearance/UnclassifiedUsersPanel.tsx
@@ -115,8 +115,8 @@ export default function UnclassifiedUsersPanel() {
 
       const response = await AdminService.userAppearance.getUnclassifiedUsers(page, pageSize, getRegionParam());
 
-      setUsers(response.items);
-      setTotalPages(response.meta.totalPages);
+      setUsers(response.data);
+      setTotalPages(response.meta?.totalPages ?? 1);
     } catch (err: any) {
       console.error('미분류 사용자 목록 조회 중 오류:', err);
       setError(err.message ?? '미분류 사용자 목록을 불러오는 중 오류가 발생했습니다.');

--- a/components/admin/appearance/UserAppearanceTable.tsx
+++ b/components/admin/appearance/UserAppearanceTable.tsx
@@ -169,8 +169,8 @@ const UserAppearanceTable = forwardRef<
         ...(userStatus && { userStatus })
       });
 
-      setUsers(response.items);
-      setTotalItems(response.meta.totalItems);
+      setUsers(response.data);
+      setTotalItems(response.meta?.total ?? 0);
     } catch (err: any) {
       console.error('사용자 목록 조회 중 오류:', err);
       setError(err.message || '사용자 목록을 불러오는 중 오류가 발생했습니다.');

--- a/components/admin/appearance/VerifiedUsersPanel.tsx
+++ b/components/admin/appearance/VerifiedUsersPanel.tsx
@@ -51,14 +51,12 @@ interface VerifiedUser {
 
 // API 응답 타입
 interface VerifiedUsersResponse {
-  items: VerifiedUser[];
+  data: VerifiedUser[];
   meta: {
-    currentPage: number;
-    itemsPerPage: number;
-    totalItems: number;
+    total: number;
+    page: number;
+    limit: number;
     totalPages: number;
-    hasNextPage: boolean;
-    hasPreviousPage: boolean;
   };
 }
 
@@ -92,8 +90,8 @@ const VerifiedUsersPanel: React.FC = () => {
         university: universityFilter || undefined
       });
 
-      setUsers(response.items);
-      setTotalItems(response.meta.totalItems);
+      setUsers(response.data);
+      setTotalItems(response.meta?.total ?? 0);
     } catch (err: any) {
       console.error('대학교 인증 사용자 조회 중 오류:', err);
       setError(err.message || '대학교 인증 사용자 목록을 불러오는 중 오류가 발생했습니다.');

--- a/components/admin/dashboard/WithdrawalStatsDashboard.tsx
+++ b/components/admin/dashboard/WithdrawalStatsDashboard.tsx
@@ -115,25 +115,40 @@ const generateEmptyMonthlyData = () => {
 // 데이터 포맷팅 함수들
 const formatData = (data: any[], type: 'daily' | 'weekly' | 'monthly') => {
   return data.map(item => {
-    let formattedDate: string;
+    const label = item.label || item.date || '';
+    let formattedDate: string = label;
 
-    switch (type) {
-      case 'daily':
-        const date = new Date(item.label);
-        formattedDate = `${(date.getMonth() + 1).toString().padStart(2, '0')}/${date.getDate().toString().padStart(2, '0')}`;
-        break;
-      case 'weekly':
-        // 주별 데이터는 "2025-05-18 ~ 2025-05-24" 형태로 오므로 시작일만 추출하여 포맷팅
-        const weekRange = item.label.split(' ~ ');
-        const startDate = new Date(weekRange[0]);
-        const month = startDate.getMonth() + 1;
-        const day = startDate.getDate();
-        formattedDate = `${month}/${day}주`;
-        break;
-      case 'monthly':
-        const monthDate = new Date(item.label);
-        formattedDate = `${monthDate.getFullYear()}년 ${monthDate.getMonth() + 1}월`;
-        break;
+    try {
+      switch (type) {
+        case 'daily': {
+          const date = new Date(label);
+          if (!isNaN(date.getTime())) {
+            formattedDate = `${(date.getMonth() + 1).toString().padStart(2, '0')}/${date.getDate().toString().padStart(2, '0')}`;
+          }
+          break;
+        }
+        case 'weekly': {
+          if (label.includes(' ~ ')) {
+            const weekRange = label.split(' ~ ');
+            const startDate = new Date(weekRange[0]);
+            if (!isNaN(startDate.getTime())) {
+              const month = startDate.getMonth() + 1;
+              const day = startDate.getDate();
+              formattedDate = `${month}/${day}주`;
+            }
+          }
+          break;
+        }
+        case 'monthly': {
+          const monthDate = new Date(label);
+          if (!isNaN(monthDate.getTime())) {
+            formattedDate = `${monthDate.getFullYear()}년 ${monthDate.getMonth() + 1}월`;
+          }
+          break;
+        }
+      }
+    } catch {
+      // 포맷팅 실패 시 원본 label 유지
     }
 
     return {


### PR DESCRIPTION
## Summary
- sometimes-api v2 엔드포인트 전면 배포에 맞춰 프론트엔드 서비스 레이어 51개 함수를 v2 API로 전환
- 함수 시그니처 유지, 내부 URL + 응답 파싱(`response.data.data`)만 변경
- POST → GET 전환 4건, 이미지 액션 3→1 통합, 채팅 커서 페이지네이션 적용

## 변경 파일
| 파일 | 변경 함수 | 주요 변경 |
|------|----------|----------|
| `dashboard.ts` | 20개 | `/admin/v2/stats/*`, POST→GET |
| `moderation.ts` | 15개 | `/admin/v2/reports/*`, `/admin/v2/profile-review/*` |
| `users.ts` | 10개 | `/admin/v2/users?filter=X` 통합 |
| `messaging.ts` | 2개 | `/admin/v2/ai-chat/*` |
| `chat.ts` | 4개 | `/admin/v2/chat/*`, 커서 기반 |

## Test plan
- [x] TypeScript 빌드 통과 (기존 테스트 파일 에러 3개 외 신규 에러 없음)
- [x] 개발 서버 정상 기동, 콘솔 에러 없음
- [ ] 어드민 대시보드 페이지 접속 후 데이터 정상 로드 확인
- [ ] 프로필 심사/유저 관리/채팅 관리 페이지 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)