### PR TITLE
feat(admin-fe): v1→v2 엔드포인트 마이그레이션 (404 해소)

### DIFF
--- a/app/services/admin/users.ts
+++ b/app/services/admin/users.ts
@@ -127,18 +127,19 @@ export const userAppearance = {
 		name?: string;
 		university?: string;
 	}) => {
-		return adminGet<{
+		const res = await adminGet<{ data: {
 			users: unknown[];
 			total: number;
 			page: number;
 			limit: number;
 			totalPages: number;
-		}>('/admin/university-verification/pending', {
+		} }>('/admin/v2/profile-review/university-verification/pending', {
 			page: String(params.page ?? 1),
 			limit: String(params.limit ?? 10),
 			name: params.name ?? '',
 			university: params.university ?? '',
 		});
+		return res.data;
 	},
 
 	bulkSetUserAppearanceGrade: async (
@@ -440,7 +441,7 @@ export const userAppearance = {
 		try {
 			;
 
-			const endpoint = '/admin/users/appearance/stats';
+			const endpoint = '/admin/v2/users/appearance/stats';
 			;
 
 			const timestamp = new Date().getTime();
@@ -456,7 +457,8 @@ export const userAppearance = {
 			let responseData: any;
 
 			try {
-				const result = await adminGet<any>(finalUrl);
+				const raw = await adminGet<{ data: any }>(finalUrl);
+				const result = raw.data;
 
 				if (!result || Object.keys(result).length === 0) {
 					return null;
@@ -715,9 +717,10 @@ export const userAppearance = {
 			if (params.name) queryParams.append('name', params.name);
 			if (params.university) queryParams.append('university', params.university);
 
-			const result = await adminGet<any>(
-				`/admin/university-verification/pending?${queryParams.toString()}`,
+			const res = await adminGet<{ data: any }>(
+				`/admin/v2/profile-review/university-verification/pending?${queryParams.toString()}`,
 			);
+			const result = res.data;
 
 			return result;
 		} catch (error: any) {
@@ -928,8 +931,8 @@ export const userEngagement = {
 			if (endDate) params.endDate = endDate;
 			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
 
-			const result = await adminGet<any>('/admin/stats/user-engagement', params);
-			return result;
+			const res = await adminGet<{ data: any }>('/admin/v2/stats/engagement', params);
+			return res.data;
 		} catch (error: any) {
 			throw error;
 		}

--- a/app/services/admin/users.ts
+++ b/app/services/admin/users.ts
@@ -927,8 +927,8 @@ export const userEngagement = {
 	getStats: async (startDate?: string, endDate?: string, includeDeleted?: boolean) => {
 		try {
 			const params: Record<string, string> = {};
-			if (startDate) params.startDate = startDate;
-			if (endDate) params.endDate = endDate;
+			if (startDate) params.from = startDate;
+			if (endDate) params.to = endDate;
 			if (includeDeleted !== undefined) params.includeDeleted = String(includeDeleted);
 
 			const res = await adminGet<{ data: any }>('/admin/v2/stats/engagement', params);

--- a/app/services/dashboard.ts
+++ b/app/services/dashboard.ts
@@ -20,8 +20,8 @@ const DASHBOARD_ENDPOINT = {
   MATCHING_FUNNEL: "/admin/dashboard/matching/funnel",
   HOURLY_SIGNUPS: "/admin/v2/dashboard/signups",
   GOALS: "/admin/goals",
-  GEM_SYSTEM_FUNNEL: "/admin/dashboard/matching/gem-system-funnel",
-  ACTIONABLE_INSIGHTS: "/admin/dashboard/actionable-insights",
+  GEM_SYSTEM_FUNNEL: "/admin/v2/dashboard/gem-system-funnel",
+  ACTIONABLE_INSIGHTS: "/admin/v2/dashboard/actionable-insights",
 } as const;
 
 export const dashboardService = {
@@ -132,7 +132,8 @@ export const dashboardService = {
       if (startDate) params.startDate = startDate;
       if (endDate) params.endDate = endDate;
       if (debug) params.debug = "true";
-      return await adminGet<GemSystemFunnelResponse>(DASHBOARD_ENDPOINT.GEM_SYSTEM_FUNNEL, params);
+      const res = await adminGet<{ data: GemSystemFunnelResponse }>(DASHBOARD_ENDPOINT.GEM_SYSTEM_FUNNEL, params);
+      return res.data;
     } catch (error) {
       console.error("구슬 시스템 퍼널 조회 실패:", error);
       throw error instanceof AdminApiError
@@ -143,7 +144,8 @@ export const dashboardService = {
 
   async getActionableInsights(): Promise<ActionableInsightsResponse> {
     try {
-      return await adminGet<ActionableInsightsResponse>(DASHBOARD_ENDPOINT.ACTIONABLE_INSIGHTS);
+      const res = await adminGet<{ data: ActionableInsightsResponse }>(DASHBOARD_ENDPOINT.ACTIONABLE_INSIGHTS);
+      return res.data;
     } catch (error) {
       console.error("실행 가능한 인사이트 조회 실패:", error);
       throw error instanceof AdminApiError

--- a/app/services/sales.ts
+++ b/app/services/sales.ts
@@ -217,7 +217,8 @@ export const salesService = {
   // MARK: - 사용자 지정 기간 매출 추이 조회
   async getTrendCustom(data: TrendCustomRequest): Promise<TrendCustomResponse> {
     try {
-      const res = await adminGet<{ data: TrendCustomResponse }>(SALES_ENDPOINT.TREND, toStringParams({ ...data, period: 'custom' }));
+      const { startDate, endDate, ...rest } = data;
+      const res = await adminGet<{ data: TrendCustomResponse }>(SALES_ENDPOINT.TREND, toStringParams({ ...rest, period: 'daily', from: startDate, to: endDate }));
       return res.data;
     } catch (error) {
       throw new SalesApiError("사용자 지정 매출액 조회 실패:", error);

--- a/app/services/sales.ts
+++ b/app/services/sales.ts
@@ -46,10 +46,7 @@ const SALES_ENDPOINT = {
   WEEKLY: "/admin/stats/sales/weekly",
   MONTHLY: "/admin/stats/sales/monthly",
   CUSTOM_PERIOD: "/admin/stats/sales/custom-period",
-  TREND_DAILY: "/admin/stats/sales/trend/daily",
-  TREND_WEEKLY: "/admin/stats/sales/trend/weekly",
-  TREND_MONTHLY: "/admin/stats/sales/trend/monthly",
-  TREND_CUSTOM: "/admin/stats/sales/trend/custom-period",
+  TREND: "/admin/v2/stats/sales/trend",
   SUCCESS_RATE: "/admin/stats/sales/success-rate",
   UNIVERSITY_RANKING: "/admin/stats/sales/university-ranking",
   PAYMENT_ANALYSIS: "/admin/stats/sales/payment-method-analysis",
@@ -190,8 +187,8 @@ export const salesService = {
   // MARK: - 일별 매출 추이 조회
   async getTrendDaily(data: GetSales): Promise<TrendDailyResponse> {
     try {
-      const result = await adminGet<TrendDailyResponse>(SALES_ENDPOINT.TREND_DAILY, toStringParams(data));
-      return result;
+      const res = await adminGet<{ data: TrendDailyResponse }>(SALES_ENDPOINT.TREND, toStringParams({ ...data, period: 'daily' }));
+      return res.data;
     } catch (error) {
       throw new SalesApiError("일별 매출 추이 조회 실패:", error);
     }
@@ -200,8 +197,8 @@ export const salesService = {
   // MARK: - 주별 매출 추이 조회
   async getTrendWeekly(data: GetSales): Promise<TrendWeeklyResponse> {
     try {
-      const result = await adminGet<TrendWeeklyResponse>(SALES_ENDPOINT.TREND_WEEKLY, toStringParams(data));
-      return result;
+      const res = await adminGet<{ data: TrendWeeklyResponse }>(SALES_ENDPOINT.TREND, toStringParams({ ...data, period: 'weekly' }));
+      return res.data;
     } catch (error) {
       throw new SalesApiError("주별 매출 추이 조회 실패:", error);
     }
@@ -210,8 +207,8 @@ export const salesService = {
   // MARK: - 월별 매출 추이 조회
   async getTrendMonthly(data: GetSales): Promise<TrendMonthlyResponse> {
     try {
-      const result = await adminGet<TrendMonthlyResponse>(SALES_ENDPOINT.TREND_MONTHLY, toStringParams(data));
-      return result;
+      const res = await adminGet<{ data: TrendMonthlyResponse }>(SALES_ENDPOINT.TREND, toStringParams({ ...data, period: 'monthly' }));
+      return res.data;
     } catch (error) {
       throw new SalesApiError("월별 매출 추이 조회 실패:", error);
     }
@@ -220,11 +217,8 @@ export const salesService = {
   // MARK: - 사용자 지정 기간 매출 추이 조회
   async getTrendCustom(data: TrendCustomRequest): Promise<TrendCustomResponse> {
     try {
-      const result = await adminPost<TrendCustomResponse>(
-        SALES_ENDPOINT.TREND_CUSTOM,
-        data,
-      );
-      return result;
+      const res = await adminGet<{ data: TrendCustomResponse }>(SALES_ENDPOINT.TREND, toStringParams({ ...data, period: 'custom' }));
+      return res.data;
     } catch (error) {
       throw new SalesApiError("사용자 지정 매출액 조회 실패:", error);
     }


### PR DESCRIPTION
## Summary
- dashboard.ts: gem-system-funnel, actionable-insights → v2 경로 전환
- users.ts: user-engagement, appearance/stats, university-verification → v2 전환
- sales.ts: trend endpoints 4개 → v2 통합 endpoint 전환
- StatsQuery 파라미터 매핑 수정 (startDate/endDate → from/to)

## 배경
v1 컨트롤러 삭제 후 프론트에서 7개 엔드포인트 404 발생. v2 경로로 전환하고 `{ data: T }` 응답 언래핑 추가.

## 의존성
⚠️ 백엔드 PR (sometimes-api feat/v2-missing-endpoints)가 먼저 머지+배포되어야 함

## Test plan
- [ ] 대시보드 퍼널 데이터 로딩 확인
- [ ] 인사이트 데이터 로딩 확인
- [ ] 유저 참여 통계 날짜 필터 작동 확인
- [ ] 외모 등급 통계 로딩 확인
- [ ] 학생증 인증 대기 목록 로딩 확인
- [ ] 매출 추이 (일/주/월/커스텀) 로딩 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)