### PR TITLE
feat(admin/ghosts): sequential prompt batch preview dialog

### DIFF
--- a/app/admin/ai-profiles/ghosts/ghost-batch-create-dialog.tsx
+++ b/app/admin/ai-profiles/ghosts/ghost-batch-create-dialog.tsx
@@ -59,7 +59,7 @@ interface GhostBatchCreateDialogProps {
 	onOpenChange: (open: boolean) => void;
 }
 
-interface EditableCard {
+export interface EditableCard {
 	item: BatchCreateResultItem;
 	nameEdit: string;
 	ageEdit: string;
@@ -74,7 +74,7 @@ interface EditableCard {
 	isSaved: boolean;
 }
 
-function toEditableCard(item: BatchCreateResultItem, defaultVendorId: string): EditableCard {
+export function toEditableCard(item: BatchCreateResultItem, defaultVendorId: string): EditableCard {
 	return {
 		item,
 		nameEdit: item.name,
@@ -258,7 +258,7 @@ function FormPhase({
 	);
 }
 
-function ResultPhase({
+export function ResultPhase({
 	result, cards, failedItems, expandedIdx, setExpandedIdx, updateCard, setCards, onClose, onReset,
 }: {
 	result: BatchCreateResult;

--- a/app/admin/ai-profiles/ghosts/ghost-batch-preview-dialog.tsx
+++ b/app/admin/ai-profiles/ghosts/ghost-batch-preview-dialog.tsx
@@ -11,7 +11,7 @@ import type {
 	ImageVendor,
 	PatchBatchPreviewItemBody,
 } from '@/app/types/ghost-injection';
-import { getAdminErrorMessage } from '@/shared/lib/http/admin-fetch';
+import { AdminApiError, getAdminErrorMessage } from '@/shared/lib/http/admin-fetch';
 import { useToast } from '@/shared/ui/admin/toast';
 import { Badge } from '@/shared/ui/badge';
 import { Button } from '@/shared/ui/button';
@@ -120,6 +120,11 @@ export function GhostBatchPreviewDialog({
 				body,
 			);
 		},
+		retry: (failureCount, error) => {
+			if (failureCount >= 1) return false;
+			return error instanceof AdminApiError && error.status === 409;
+		},
+		retryDelay: 5000,
 		onMutate: ({ itemId, body }) => {
 			setPendingItemId(itemId);
 			setPendingAction(body.action);
@@ -183,6 +188,29 @@ export function GhostBatchPreviewDialog({
 		},
 		onError: (error) => toast.error(getAdminErrorMessage(error)),
 	});
+
+	const handleRestartPreview = () => {
+		if (!previewRoot) return;
+		ghostInjection.deleteBatchPreview(previewRoot.previewId).catch(() => undefined);
+		setPreviewRoot(null);
+		setSelectedIds(new Set());
+		setPhase('setup');
+	};
+
+	useEffect(() => {
+		if (!previewRoot) return;
+		const expiresAtMs = new Date(previewRoot.expiresAt).getTime();
+		if (Number.isNaN(expiresAtMs)) return;
+		const check = () => {
+			if (Date.now() >= expiresAtMs && phase === 'review') {
+				toast.error('미리보기가 만료되었습니다.');
+				onOpenChange(false);
+			}
+		};
+		check();
+		const id = window.setInterval(check, 1000);
+		return () => window.clearInterval(id);
+	}, [previewRoot, phase, toast, onOpenChange]);
 
 	const itemsList: BatchPreviewItem[] = useMemo(() => {
 		if (!previewRoot) return [];
@@ -316,6 +344,7 @@ export function GhostBatchPreviewDialog({
 								{!stream.isComplete && !stream.error ? (
 									<Loader2 className="h-3.5 w-3.5 animate-spin text-slate-400" />
 								) : null}
+								<ExpiryCountdown expiresAt={previewRoot.expiresAt} />
 							</div>
 							<p className="mt-1 text-sm text-slate-500">
 								프롬프트를 수정하거나 개별 항목을 재생성할 수 있습니다. 선택한
@@ -351,8 +380,18 @@ export function GhostBatchPreviewDialog({
 								</div>
 							) : null}
 							{stream.error ? (
-								<div className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
-									{stream.error}
+								<div className="mt-3 flex items-center justify-between gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+									<span className="truncate">{stream.error}</span>
+									{stream.errorRetryable ? (
+										<Button
+											size="sm"
+											variant="outline"
+											className="h-7 border-red-300 text-red-700 hover:bg-red-100"
+											onClick={handleRestartPreview}
+										>
+											다시 시작
+										</Button>
+									) : null}
 								</div>
 							) : null}
 						</div>
@@ -603,5 +642,42 @@ function SetupPhase({
 				</div>
 			</div>
 		</div>
+	);
+}
+
+function ExpiryCountdown({ expiresAt }: { expiresAt: string }) {
+	const [remainingMs, setRemainingMs] = useState(() =>
+		Math.max(0, new Date(expiresAt).getTime() - Date.now()),
+	);
+
+	useEffect(() => {
+		const target = new Date(expiresAt).getTime();
+		const id = window.setInterval(() => {
+			setRemainingMs(Math.max(0, target - Date.now()));
+		}, 1000);
+		return () => window.clearInterval(id);
+	}, [expiresAt]);
+
+	const totalSec = Math.floor(remainingMs / 1000);
+	const mm = String(Math.floor(totalSec / 60)).padStart(2, '0');
+	const ss = String(totalSec % 60).padStart(2, '0');
+
+	const tone =
+		totalSec <= 60
+			? 'border-red-300 bg-red-50 text-red-700'
+			: totalSec <= 180
+				? 'border-amber-300 bg-amber-50 text-amber-700'
+				: 'border-slate-200 bg-white text-slate-600';
+
+	return (
+		<span
+			className={cn(
+				'rounded-md border px-2 py-0.5 text-xs tabular-nums',
+				tone,
+			)}
+			title="미리보기 만료까지 남은 시간"
+		>
+			만료 {mm}:{ss}
+		</span>
 	);
 }

--- a/app/admin/ai-profiles/ghosts/ghost-batch-preview-dialog.tsx
+++ b/app/admin/ai-profiles/ghosts/ghost-batch-preview-dialog.tsx
@@ -1,0 +1,515 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { CheckSquare, Loader2, Minus, Plus, Square, Trash2 } from 'lucide-react';
+import { ghostInjection } from '@/app/services/admin/ghost-injection';
+import type {
+	BatchCreateResult,
+	BatchPreviewItem,
+	BatchPreviewRoot,
+	ImageVendor,
+	PatchBatchPreviewItemBody,
+} from '@/app/types/ghost-injection';
+import { getAdminErrorMessage } from '@/shared/lib/http/admin-fetch';
+import { useToast } from '@/shared/ui/admin/toast';
+import { Badge } from '@/shared/ui/badge';
+import { Button } from '@/shared/ui/button';
+import { Dialog, DialogContent } from '@/shared/ui/dialog';
+import { Input } from '@/shared/ui/input';
+import { Label } from '@/shared/ui/label';
+import { cn } from '@/shared/utils';
+import {
+	DEFAULT_VENDOR,
+	DEFAULT_VENDOR_ID,
+	findVendorOption,
+	GHOST_VENDOR_OPTIONS,
+} from '../_shared/ghost-vendor-options';
+import { ghostInjectionKeys } from '../_shared/query-keys';
+import { ReasonInput, isReasonValid } from '../_shared/reason-input';
+import { VendorRadioGroup } from '../_shared/vendor-radio-group';
+import {
+	ResultPhase,
+	toEditableCard,
+	type EditableCard,
+} from './ghost-batch-create-dialog';
+import { GhostPreviewCard } from './ghost-preview-card';
+
+type Phase = 'setup' | 'review' | 'confirming' | 'result';
+
+interface GhostBatchPreviewDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+export function GhostBatchPreviewDialog({
+	open,
+	onOpenChange,
+}: GhostBatchPreviewDialogProps) {
+	const toast = useToast();
+	const queryClient = useQueryClient();
+
+	const [phase, setPhase] = useState<Phase>('setup');
+	const [count, setCount] = useState(1);
+	const [vendorId, setVendorId] = useState(DEFAULT_VENDOR_ID);
+	const [reason, setReason] = useState('');
+	const [previewRoot, setPreviewRoot] = useState<BatchPreviewRoot | null>(null);
+	const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+	const [pendingItemId, setPendingItemId] = useState<string | null>(null);
+	const [pendingAction, setPendingAction] = useState<'edit' | 'regenerate' | null>(
+		null,
+	);
+	const [confirmResult, setConfirmResult] = useState<BatchCreateResult | null>(
+		null,
+	);
+	const [resultCards, setResultCards] = useState<EditableCard[]>([]);
+	const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
+
+	useEffect(() => {
+		if (open) {
+			setPhase('setup');
+			setCount(1);
+			setVendorId(DEFAULT_VENDOR_ID);
+			setReason('');
+			setPreviewRoot(null);
+			setSelectedIds(new Set());
+			setPendingItemId(null);
+			setPendingAction(null);
+			setConfirmResult(null);
+			setResultCards([]);
+			setExpandedIdx(null);
+		}
+	}, [open]);
+
+	const createMutation = useMutation({
+		mutationFn: () => {
+			const vendor: ImageVendor =
+				findVendorOption(vendorId)?.value ?? DEFAULT_VENDOR;
+			return ghostInjection.createBatchPreview({ count, vendor });
+		},
+		onSuccess: (data) => {
+			setPreviewRoot(data);
+			setSelectedIds(new Set(Object.keys(data.items)));
+			setPhase('review');
+		},
+		onError: (error) => toast.error(getAdminErrorMessage(error)),
+	});
+
+	const patchMutation = useMutation({
+		mutationFn: ({
+			itemId,
+			body,
+		}: {
+			itemId: string;
+			body: PatchBatchPreviewItemBody;
+		}) => {
+			if (!previewRoot) throw new Error('previewRoot 없음');
+			return ghostInjection.patchBatchPreviewItem(
+				previewRoot.previewId,
+				itemId,
+				body,
+			);
+		},
+		onMutate: ({ itemId, body }) => {
+			setPendingItemId(itemId);
+			setPendingAction(body.action);
+		},
+		onSuccess: (updated) => {
+			setPreviewRoot((prev) => {
+				if (!prev) return prev;
+				return {
+					...prev,
+					items: { ...prev.items, [updated.itemId]: updated },
+				};
+			});
+			toast.success('프롬프트가 업데이트되었습니다.');
+		},
+		onError: (error) => toast.error(getAdminErrorMessage(error)),
+		onSettled: () => {
+			setPendingItemId(null);
+			setPendingAction(null);
+		},
+	});
+
+	const confirmMutation = useMutation({
+		mutationFn: () => {
+			if (!previewRoot) throw new Error('previewRoot 없음');
+			return ghostInjection.confirmBatchPreview(previewRoot.previewId, {
+				itemIds: Array.from(selectedIds),
+				reason: reason.trim(),
+			});
+		},
+		onSuccess: (data) => {
+			if (!data) return;
+			setConfirmResult(data);
+			const usedVendorId =
+				GHOST_VENDOR_OPTIONS.find(
+					(option) => option.value === data.vendor && !option.disabled,
+				)?.id ?? DEFAULT_VENDOR_ID;
+			setResultCards(
+				data.results
+					.filter((result) => result.status === 'success')
+					.map((result) => toEditableCard(result, usedVendorId)),
+			);
+			setPhase('result');
+			toast.success(`${data.success}개 프로필이 생성되었습니다.`);
+			queryClient.invalidateQueries({ queryKey: ghostInjectionKeys.ghosts() });
+			queryClient.invalidateQueries({ queryKey: ghostInjectionKeys.status() });
+		},
+		onError: (error) => {
+			toast.error(getAdminErrorMessage(error));
+			setPhase('review');
+		},
+	});
+
+	const deleteMutation = useMutation({
+		mutationFn: () => {
+			if (!previewRoot) throw new Error('previewRoot 없음');
+			return ghostInjection.deleteBatchPreview(previewRoot.previewId);
+		},
+		onSuccess: () => {
+			toast.success('미리보기가 취소되었습니다.');
+			onOpenChange(false);
+		},
+		onError: (error) => toast.error(getAdminErrorMessage(error)),
+	});
+
+	const itemsList: BatchPreviewItem[] = useMemo(() => {
+		if (!previewRoot) return [];
+		return Object.values(previewRoot.items);
+	}, [previewRoot]);
+
+	const allSelected =
+		itemsList.length > 0 && selectedIds.size === itemsList.length;
+
+	const handleToggleSelect = (itemId: string) => {
+		setSelectedIds((prev) => {
+			const next = new Set(prev);
+			if (next.has(itemId)) next.delete(itemId);
+			else next.add(itemId);
+			return next;
+		});
+	};
+
+	const handleToggleSelectAll = () => {
+		if (allSelected) {
+			setSelectedIds(new Set());
+		} else {
+			setSelectedIds(new Set(itemsList.map((item) => item.itemId)));
+		}
+	};
+
+	const handleEditSlot = (
+		itemId: string,
+		slotIndex: 0 | 1 | 2,
+		nextPrompt: string,
+	) => {
+		patchMutation.mutate({
+			itemId,
+			body: {
+				action: 'edit',
+				slotPrompts: [{ slotIndex, prompt: nextPrompt }],
+			},
+		});
+	};
+
+	const handleRegenerateItem = (itemId: string) => {
+		patchMutation.mutate({
+			itemId,
+			body: { action: 'regenerate', preserveProfile: true },
+		});
+	};
+
+	const isBusy =
+		createMutation.isPending ||
+		patchMutation.isPending ||
+		confirmMutation.isPending ||
+		deleteMutation.isPending;
+
+	const canStartConfirm =
+		selectedIds.size > 0 && isReasonValid(reason) && !isBusy;
+
+	const handleStartConfirm = () => {
+		setPhase('confirming');
+		confirmMutation.mutate();
+	};
+
+	const handleDialogOpenChange = (next: boolean) => {
+		if (!isBusy) onOpenChange(next);
+	};
+
+	const failedItems =
+		confirmResult?.results.filter((result) => result.status === 'failed') ?? [];
+
+	return (
+		<Dialog open={open} onOpenChange={handleDialogOpenChange}>
+			<DialogContent className="flex h-[92vh] max-w-7xl flex-col p-0">
+				{phase === 'setup' ? (
+					<SetupPhase
+						count={count}
+						setCount={setCount}
+						vendorId={vendorId}
+						setVendorId={setVendorId}
+						isPending={createMutation.isPending}
+						onCancel={() => onOpenChange(false)}
+						onSubmit={() => createMutation.mutate()}
+					/>
+				) : null}
+
+				{phase === 'review' && previewRoot ? (
+					<div className="flex flex-1 flex-col overflow-hidden">
+						<div className="border-b px-6 py-4">
+							<div className="flex items-center gap-2">
+								<h2 className="text-lg font-semibold text-slate-900">
+									프로필 미리보기 검토
+								</h2>
+								<Badge variant="outline" className="text-xs">
+									{previewRoot.vendor}
+								</Badge>
+								<Badge variant="secondary" className="text-xs">
+									총 {itemsList.length}개
+								</Badge>
+							</div>
+							<p className="mt-1 text-sm text-slate-500">
+								프롬프트를 수정하거나 개별 항목을 재생성할 수 있습니다. 선택한
+								항목만 실제 프로필로 생성됩니다.
+							</p>
+						</div>
+
+						<div className="border-b bg-slate-50 px-6 py-3">
+							<div className="flex items-center justify-between">
+								<Button
+									size="sm"
+									variant="ghost"
+									onClick={handleToggleSelectAll}
+									disabled={isBusy}
+								>
+									{allSelected ? (
+										<>
+											<CheckSquare className="mr-1 h-4 w-4" />
+											전체 해제
+										</>
+									) : (
+										<>
+											<Square className="mr-1 h-4 w-4" />
+											전체 선택
+										</>
+									)}
+								</Button>
+								<span className="text-xs text-slate-500">
+									<span className="font-semibold text-slate-900">
+										{selectedIds.size}
+									</span>
+									개 선택됨
+								</span>
+							</div>
+						</div>
+
+						<div className="flex-1 overflow-y-auto px-6 py-4">
+							<div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+								{itemsList.map((item) => (
+									<GhostPreviewCard
+										key={item.itemId}
+										item={item}
+										selected={selectedIds.has(item.itemId)}
+										onToggleSelect={() => handleToggleSelect(item.itemId)}
+										onEditSlot={(slotIndex, nextPrompt) =>
+											handleEditSlot(item.itemId, slotIndex, nextPrompt)
+										}
+										onRegenerate={() => handleRegenerateItem(item.itemId)}
+										isSaving={
+											pendingItemId === item.itemId && pendingAction === 'edit'
+										}
+										isRegenerating={
+											pendingItemId === item.itemId &&
+											pendingAction === 'regenerate'
+										}
+									/>
+								))}
+							</div>
+						</div>
+
+						<div className="space-y-3 border-t px-6 py-4">
+							<ReasonInput
+								value={reason}
+								onChange={setReason}
+								minLength={10}
+								rows={2}
+							/>
+							<div className="flex items-center justify-between">
+								<Button
+									variant="ghost"
+									className="text-red-600 hover:bg-red-50 hover:text-red-700"
+									disabled={isBusy}
+									onClick={() => deleteMutation.mutate()}
+								>
+									<Trash2 className="mr-1 h-4 w-4" />
+									취소 (미리보기 삭제)
+								</Button>
+								<div className="flex items-center gap-2">
+									<span className="text-xs text-slate-500">
+										선택 {selectedIds.size}개 생성
+									</span>
+									<Button
+										disabled={!canStartConfirm}
+										onClick={handleStartConfirm}
+									>
+										확정 생성
+									</Button>
+								</div>
+							</div>
+						</div>
+					</div>
+				) : null}
+
+				{phase === 'confirming' ? (
+					<div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 py-16">
+						<Loader2 className="h-10 w-10 animate-spin text-slate-400" />
+						<p className="text-sm text-slate-600">
+							선택한 {selectedIds.size}개 프로필을 생성 중입니다…
+						</p>
+						<p className="text-xs text-slate-400">
+							이미지 생성으로 시간이 소요될 수 있습니다.
+						</p>
+					</div>
+				) : null}
+
+				{phase === 'result' && confirmResult ? (
+					<ResultPhase
+						result={confirmResult}
+						cards={resultCards}
+						failedItems={failedItems}
+						expandedIdx={expandedIdx}
+						setExpandedIdx={setExpandedIdx}
+						updateCard={(idx, patch) =>
+							setResultCards((prev) => {
+								const next = [...prev];
+								next[idx] = { ...prev[idx], ...patch };
+								return next;
+							})
+						}
+						setCards={setResultCards}
+						onClose={() => onOpenChange(false)}
+						onReset={() => {
+							setPhase('setup');
+							setConfirmResult(null);
+							setResultCards([]);
+							setExpandedIdx(null);
+							setPreviewRoot(null);
+							setSelectedIds(new Set());
+							setReason('');
+						}}
+					/>
+				) : null}
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+interface SetupPhaseProps {
+	count: number;
+	setCount: (next: number) => void;
+	vendorId: string;
+	setVendorId: (next: string) => void;
+	isPending: boolean;
+	onCancel: () => void;
+	onSubmit: () => void;
+}
+
+function SetupPhase({
+	count,
+	setCount,
+	vendorId,
+	setVendorId,
+	isPending,
+	onCancel,
+	onSubmit,
+}: SetupPhaseProps) {
+	const canSubmit = count >= 1 && count <= 50 && !isPending;
+
+	return (
+		<div className="flex flex-1 flex-col overflow-hidden">
+			<div className="border-b px-6 py-4">
+				<h2 className="text-lg font-semibold text-slate-900">
+					가상 프로필 미리보기 생성
+				</h2>
+				<p className="mt-1 text-sm text-slate-500">
+					프롬프트 검토 후 선택한 항목만 실제 프로필로 생성합니다.
+				</p>
+			</div>
+
+			<div className="flex-1 overflow-y-auto px-6 py-6">
+				<div className="mx-auto max-w-3xl space-y-6">
+					<div className="space-y-1">
+						<Label className="text-sm font-semibold text-slate-800">
+							생성 수량 *
+						</Label>
+						<div className="flex items-center gap-2">
+							<Button
+								variant="outline"
+								size="icon"
+								className="h-9 w-9"
+								disabled={count <= 1}
+								onClick={() => setCount(Math.max(1, count - 1))}
+							>
+								<Minus className="h-3 w-3" />
+							</Button>
+							<Input
+								type="number"
+								min={1}
+								max={50}
+								value={count}
+								onChange={(event) => {
+									const value = Number(event.target.value);
+									if (Number.isFinite(value) && value >= 1 && value <= 50) {
+										setCount(value);
+									}
+								}}
+								className={cn('h-9 w-20 text-center tabular-nums')}
+							/>
+							<Button
+								variant="outline"
+								size="icon"
+								className="h-9 w-9"
+								disabled={count >= 50}
+								onClick={() => setCount(Math.min(50, count + 1))}
+							>
+								<Plus className="h-3 w-3" />
+							</Button>
+							<span className="text-xs text-slate-500">최대 50개</span>
+						</div>
+					</div>
+
+					<div className="border-t pt-5">
+						<VendorRadioGroup
+							selectedId={vendorId}
+							onChange={setVendorId}
+							columns={2}
+						/>
+					</div>
+				</div>
+			</div>
+
+			<div className="flex items-center justify-between border-t px-6 py-4">
+				<p className="text-xs text-slate-500">
+					AI가 {count}개의 프로필과 각 슬롯의 이미지 프롬프트를 생성합니다.
+				</p>
+				<div className="flex items-center gap-2">
+					<Button variant="outline" onClick={onCancel}>
+						취소
+					</Button>
+					<Button onClick={onSubmit} disabled={!canSubmit}>
+						{isPending ? (
+							<>
+								<Loader2 className="mr-1 h-4 w-4 animate-spin" />
+								생성 중…
+							</>
+						) : (
+							`${count}개 미리보기 생성`
+						)}
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/app/admin/ai-profiles/ghosts/ghost-batch-preview-dialog.tsx
+++ b/app/admin/ai-profiles/ghosts/ghost-batch-preview-dialog.tsx
@@ -34,6 +34,13 @@ import {
 	type EditableCard,
 } from './ghost-batch-create-dialog';
 import { GhostPreviewCard } from './ghost-preview-card';
+import { useBatchPreviewStream } from './use-batch-preview-stream';
+
+const STAGE_LABELS: Record<'profile' | 'persona' | 'slot-prompt', string> = {
+	profile: '프로필 생성',
+	persona: '페르소나 생성',
+	'slot-prompt': '슬롯 프롬프트 생성',
+};
 
 type Phase = 'setup' | 'review' | 'confirming' | 'result';
 
@@ -89,11 +96,14 @@ export function GhostBatchPreviewDialog({
 		},
 		onSuccess: (data) => {
 			setPreviewRoot(data);
+			// items may be empty on skeleton — selection will be recomputed as items stream in
 			setSelectedIds(new Set(Object.keys(data.items)));
 			setPhase('review');
 		},
 		onError: (error) => toast.error(getAdminErrorMessage(error)),
 	});
+
+	const stream = useBatchPreviewStream(previewRoot?.previewId ?? null);
 
 	const patchMutation = useMutation({
 		mutationFn: ({
@@ -176,8 +186,36 @@ export function GhostBatchPreviewDialog({
 
 	const itemsList: BatchPreviewItem[] = useMemo(() => {
 		if (!previewRoot) return [];
-		return Object.values(previewRoot.items);
-	}, [previewRoot]);
+		const merged: Record<string, BatchPreviewItem> = {
+			...previewRoot.items,
+			...stream.itemsReady,
+		};
+		return Object.values(merged);
+	}, [previewRoot, stream.itemsReady]);
+
+	// Auto-select items as they stream in (default to selected, matching prior UX)
+	useEffect(() => {
+		const ids = Object.keys(stream.itemsReady);
+		if (ids.length === 0) return;
+		setSelectedIds((prev) => {
+			const next = new Set(prev);
+			let changed = false;
+			for (const id of ids) {
+				if (!next.has(id)) {
+					next.add(id);
+					changed = true;
+				}
+			}
+			return changed ? next : prev;
+		});
+	}, [stream.itemsReady]);
+
+	// Surface stream error once
+	useEffect(() => {
+		if (stream.error) {
+			toast.error(stream.error);
+		}
+	}, [stream.error, toast]);
 
 	const allSelected =
 		itemsList.length > 0 && selectedIds.size === itemsList.length;
@@ -227,7 +265,11 @@ export function GhostBatchPreviewDialog({
 		deleteMutation.isPending;
 
 	const canStartConfirm =
-		selectedIds.size > 0 && isReasonValid(reason) && !isBusy;
+		selectedIds.size > 0 &&
+		isReasonValid(reason) &&
+		!isBusy &&
+		stream.isComplete &&
+		!stream.error;
 
 	const handleStartConfirm = () => {
 		setPhase('confirming');
@@ -267,13 +309,52 @@ export function GhostBatchPreviewDialog({
 									{previewRoot.vendor}
 								</Badge>
 								<Badge variant="secondary" className="text-xs">
-									총 {itemsList.length}개
+									{stream.isComplete
+										? `총 ${itemsList.length}개`
+										: `${stream.completed}/${stream.total || count} 생성 중`}
 								</Badge>
+								{!stream.isComplete && !stream.error ? (
+									<Loader2 className="h-3.5 w-3.5 animate-spin text-slate-400" />
+								) : null}
 							</div>
 							<p className="mt-1 text-sm text-slate-500">
 								프롬프트를 수정하거나 개별 항목을 재생성할 수 있습니다. 선택한
 								항목만 실제 프로필로 생성됩니다.
 							</p>
+							{!stream.isComplete && !stream.error ? (
+								<div className="mt-3 space-y-1">
+									<div className="flex items-center justify-between text-xs text-slate-500">
+										<span>
+											{stream.stage ? STAGE_LABELS[stream.stage] : '준비 중'}
+										</span>
+										<span className="tabular-nums">
+											{stream.completed}/{stream.total || count}
+										</span>
+									</div>
+									<div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-100">
+										<div
+											className="h-full rounded-full bg-slate-900 transition-[width] duration-300"
+											style={{
+												width: `${
+													stream.total > 0
+														? Math.min(
+																100,
+																Math.round(
+																	(stream.completed / stream.total) * 100,
+																),
+															)
+														: 0
+												}%`,
+											}}
+										/>
+									</div>
+								</div>
+							) : null}
+							{stream.error ? (
+								<div className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+									{stream.error}
+								</div>
+							) : null}
 						</div>
 
 						<div className="border-b bg-slate-50 px-6 py-3">
@@ -306,27 +387,38 @@ export function GhostBatchPreviewDialog({
 						</div>
 
 						<div className="flex-1 overflow-y-auto px-6 py-4">
-							<div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-								{itemsList.map((item) => (
-									<GhostPreviewCard
-										key={item.itemId}
-										item={item}
-										selected={selectedIds.has(item.itemId)}
-										onToggleSelect={() => handleToggleSelect(item.itemId)}
-										onEditSlot={(slotIndex, nextPrompt) =>
-											handleEditSlot(item.itemId, slotIndex, nextPrompt)
-										}
-										onRegenerate={() => handleRegenerateItem(item.itemId)}
-										isSaving={
-											pendingItemId === item.itemId && pendingAction === 'edit'
-										}
-										isRegenerating={
-											pendingItemId === item.itemId &&
-											pendingAction === 'regenerate'
-										}
-									/>
-								))}
-							</div>
+							{itemsList.length === 0 && !stream.error ? (
+								<div className="flex h-full flex-col items-center justify-center gap-3 py-12 text-slate-500">
+									<Loader2 className="h-8 w-8 animate-spin text-slate-400" />
+									<p className="text-sm">
+										{stream.total > 0
+											? `0/${stream.total} 생성 중…`
+											: '미리보기를 준비 중입니다…'}
+									</p>
+								</div>
+							) : (
+								<div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+									{itemsList.map((item) => (
+										<GhostPreviewCard
+											key={item.itemId}
+											item={item}
+											selected={selectedIds.has(item.itemId)}
+											onToggleSelect={() => handleToggleSelect(item.itemId)}
+											onEditSlot={(slotIndex, nextPrompt) =>
+												handleEditSlot(item.itemId, slotIndex, nextPrompt)
+											}
+											onRegenerate={() => handleRegenerateItem(item.itemId)}
+											isSaving={
+												pendingItemId === item.itemId && pendingAction === 'edit'
+											}
+											isRegenerating={
+												pendingItemId === item.itemId &&
+												pendingAction === 'regenerate'
+											}
+										/>
+									))}
+								</div>
+							)}
 						</div>
 
 						<div className="space-y-3 border-t px-6 py-4">

--- a/app/admin/ai-profiles/ghosts/ghost-preview-card.tsx
+++ b/app/admin/ai-profiles/ghosts/ghost-preview-card.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ChevronDown, Loader2, RefreshCw, Save } from 'lucide-react';
+import type { BatchPreviewItem } from '@/app/types/ghost-injection';
+import { Badge } from '@/shared/ui/badge';
+import { Button } from '@/shared/ui/button';
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from '@/shared/ui/collapsible';
+import { Textarea } from '@/shared/ui/textarea';
+import { cn } from '@/shared/utils';
+import { RankBadge } from '../_shared/rank-badge';
+
+interface GhostPreviewCardProps {
+	item: BatchPreviewItem;
+	selected: boolean;
+	onToggleSelect: () => void;
+	onEditSlot: (slotIndex: 0 | 1 | 2, nextPrompt: string) => void;
+	onRegenerate: () => void;
+	isSaving?: boolean;
+	isRegenerating?: boolean;
+}
+
+export function GhostPreviewCard({
+	item,
+	selected,
+	onToggleSelect,
+	onEditSlot,
+	onRegenerate,
+	isSaving = false,
+	isRegenerating = false,
+}: GhostPreviewCardProps) {
+	return (
+		<div
+			className={cn(
+				'flex flex-col gap-3 rounded-xl border bg-white p-4 shadow-sm transition-all',
+				selected
+					? 'border-slate-900 ring-2 ring-slate-900/10'
+					: 'border-slate-200 hover:border-slate-300',
+			)}
+		>
+			<div className="flex items-start justify-between gap-3">
+				<div className="flex flex-1 items-start gap-3">
+					<input
+						type="checkbox"
+						checked={selected}
+						onChange={onToggleSelect}
+						className="mt-1 h-4 w-4 shrink-0 cursor-pointer rounded border-slate-300 text-slate-900 focus:ring-slate-400"
+						aria-label="프로필 선택"
+					/>
+					<div className="min-w-0 flex-1 space-y-1.5">
+						<div className="flex flex-wrap items-center gap-2">
+							<span className="text-sm font-semibold text-slate-900">
+								{item.profile.name}
+							</span>
+							<span className="text-xs text-slate-500">
+								만 {item.profile.age}세
+							</span>
+							<Badge variant="outline" className="text-[10px]">
+								{item.profile.mbti}
+							</Badge>
+							{item.profile.rank ? (
+								<RankBadge rank={item.profile.rank} />
+							) : null}
+						</div>
+						<div className="text-xs text-slate-500">
+							<span className="font-medium text-slate-700">
+								{item.university.name}
+							</span>
+							<span className="mx-1 text-slate-300">·</span>
+							<span>{item.department.name}</span>
+						</div>
+						{item.archetype.name ? (
+							<div className="text-[11px] text-slate-400">
+								아키타입: <span className="text-slate-600">{item.archetype.name}</span>
+							</div>
+						) : null}
+					</div>
+				</div>
+			</div>
+
+			{item.profile.introduction ? (
+				<p className="line-clamp-2 text-xs text-slate-600">
+					{item.profile.introduction}
+				</p>
+			) : null}
+
+			<div className="space-y-2">
+				{item.slotPrompts
+					.slice()
+					.sort((a, b) => a.slotIndex - b.slotIndex)
+					.map((slot) => (
+						<SlotPromptEditor
+							key={slot.slotIndex}
+							slotIndex={slot.slotIndex}
+							initialPrompt={slot.prompt}
+							personaDescriptor={slot.generationContext.personaDescriptor}
+							sceneDescriptor={slot.generationContext.sceneDescriptor}
+							onSave={(next) => onEditSlot(slot.slotIndex, next)}
+							isSaving={isSaving}
+						/>
+					))}
+			</div>
+
+			<div className="flex items-center justify-end border-t pt-3">
+				<Button
+					size="sm"
+					variant="outline"
+					disabled={isRegenerating || isSaving}
+					onClick={onRegenerate}
+				>
+					{isRegenerating ? (
+						<>
+							<Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+							재생성 중…
+						</>
+					) : (
+						<>
+							<RefreshCw className="mr-1 h-3.5 w-3.5" />
+							전체 재생성
+						</>
+					)}
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+interface SlotPromptEditorProps {
+	slotIndex: 0 | 1 | 2;
+	initialPrompt: string;
+	personaDescriptor: string;
+	sceneDescriptor: string;
+	onSave: (nextPrompt: string) => void;
+	isSaving: boolean;
+}
+
+function SlotPromptEditor({
+	slotIndex,
+	initialPrompt,
+	personaDescriptor,
+	sceneDescriptor,
+	onSave,
+	isSaving,
+}: SlotPromptEditorProps) {
+	const [value, setValue] = useState(initialPrompt);
+	const [open, setOpen] = useState(false);
+
+	useEffect(() => {
+		setValue(initialPrompt);
+	}, [initialPrompt]);
+
+	const dirty = value !== initialPrompt;
+
+	return (
+		<Collapsible open={open} onOpenChange={setOpen}>
+			<div className="rounded-lg border border-slate-200 bg-slate-50">
+				<CollapsibleTrigger asChild>
+					<button
+						type="button"
+						className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-100"
+					>
+						<span className="flex items-center gap-2">
+							<Badge variant="secondary" className="text-[10px]">
+								Slot {slotIndex + 1}
+							</Badge>
+							<span className="truncate text-slate-500">
+								{sceneDescriptor}
+							</span>
+						</span>
+						<ChevronDown
+							className={cn(
+								'h-3.5 w-3.5 shrink-0 text-slate-400 transition-transform',
+								open && 'rotate-180',
+							)}
+						/>
+					</button>
+				</CollapsibleTrigger>
+				<CollapsibleContent className="space-y-2 border-t border-slate-200 px-3 py-3">
+					<div className="text-[10px] text-slate-400">
+						<span className="font-medium text-slate-500">페르소나:</span>{' '}
+						{personaDescriptor}
+					</div>
+					<Textarea
+						value={value}
+						onChange={(event) => setValue(event.target.value)}
+						rows={4}
+						className="text-xs"
+					/>
+					<div className="flex items-center justify-end">
+						<Button
+							size="sm"
+							variant={dirty ? 'default' : 'outline'}
+							disabled={!dirty || isSaving}
+							onClick={() => onSave(value)}
+						>
+							{isSaving ? (
+								<>
+									<Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+									저장 중…
+								</>
+							) : (
+								<>
+									<Save className="mr-1 h-3.5 w-3.5" />
+									저장
+								</>
+							)}
+						</Button>
+					</div>
+				</CollapsibleContent>
+			</div>
+		</Collapsible>
+	);
+}

--- a/app/admin/ai-profiles/ghosts/ghosts-client.tsx
+++ b/app/admin/ai-profiles/ghosts/ghosts-client.tsx
@@ -12,7 +12,7 @@ import type {
 import { Alert, AlertDescription } from '@/shared/ui/alert';
 import { Button } from '@/shared/ui/button';
 import { ghostInjectionKeys } from '../_shared/query-keys';
-import { GhostBatchCreateDialog } from './ghost-batch-create-dialog';
+import { GhostBatchPreviewDialog } from './ghost-batch-preview-dialog';
 import { GhostBulkActions } from './ghost-bulk-actions';
 import { GhostBulkDeleteDialog } from './ghost-bulk-delete-dialog';
 import { GhostCardView } from './ghost-card-view';
@@ -234,7 +234,7 @@ export function GhostsClient() {
 				</div>
 			</div>
 
-			<GhostBatchCreateDialog open={createOpen} onOpenChange={setCreateOpen} />
+			<GhostBatchPreviewDialog open={createOpen} onOpenChange={setCreateOpen} />
 			<GhostDetailDrawer
 				key={selectedGhostId ?? 'closed'}
 				ghostAccountId={selectedGhostId}

--- a/app/admin/ai-profiles/ghosts/use-batch-preview-stream.ts
+++ b/app/admin/ai-profiles/ghosts/use-batch-preview-stream.ts
@@ -1,0 +1,101 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { BatchPreviewItem } from '@/app/types/ghost-injection';
+
+export interface PreviewStreamState {
+	isConnected: boolean;
+	completed: number;
+	total: number;
+	stage?: 'profile' | 'persona' | 'slot-prompt';
+	itemsReady: Record<string, BatchPreviewItem>;
+	isComplete: boolean;
+	error: string | null;
+	elapsedMs: number | null;
+}
+
+const initial: PreviewStreamState = {
+	isConnected: false,
+	completed: 0,
+	total: 0,
+	itemsReady: {},
+	isComplete: false,
+	error: null,
+	elapsedMs: null,
+};
+
+export function useBatchPreviewStream(previewId: string | null) {
+	const [state, setState] = useState<PreviewStreamState>(initial);
+	const sourceRef = useRef<EventSource | null>(null);
+
+	useEffect(() => {
+		if (!previewId) {
+			setState(initial);
+			return;
+		}
+
+		const url = `/api/admin-proxy/admin/ghost-injection/batch-preview/${previewId}/stream`;
+		const es = new EventSource(url, { withCredentials: true });
+		sourceRef.current = es;
+
+		es.addEventListener('open', () => setState((s) => ({ ...s, isConnected: true })));
+
+		es.addEventListener('progress', (ev) => {
+			try {
+				const data = JSON.parse((ev as MessageEvent).data);
+				setState((s) => ({
+					...s,
+					completed: data.completed ?? s.completed,
+					total: data.total ?? s.total,
+					stage: data.stage ?? s.stage,
+				}));
+			} catch {
+				/* ignore */
+			}
+		});
+
+		es.addEventListener('item-ready', (ev) => {
+			try {
+				const data = JSON.parse((ev as MessageEvent).data);
+				if (data?.item?.itemId) {
+					setState((s) => ({
+						...s,
+						itemsReady: { ...s.itemsReady, [data.item.itemId]: data.item },
+					}));
+				}
+			} catch {
+				/* ignore */
+			}
+		});
+
+		es.addEventListener('complete', (ev) => {
+			let elapsed: number | null = null;
+			try {
+				elapsed = JSON.parse((ev as MessageEvent).data)?.elapsedMs ?? null;
+			} catch {
+				/* ignore */
+			}
+			setState((s) => ({ ...s, isComplete: true, elapsedMs: elapsed }));
+			es.close();
+		});
+
+		es.addEventListener('error', (ev) => {
+			let msg = 'SSE connection error';
+			try {
+				msg = JSON.parse((ev as MessageEvent).data)?.message ?? msg;
+			} catch {
+				/* network error event has no data */
+			}
+			setState((s) => ({ ...s, error: msg, isComplete: true }));
+			es.close();
+		});
+
+		return () => {
+			es.close();
+			sourceRef.current = null;
+			setState(initial);
+		};
+	}, [previewId]);
+
+	return state;
+}

--- a/app/admin/ai-profiles/ghosts/use-batch-preview-stream.ts
+++ b/app/admin/ai-profiles/ghosts/use-batch-preview-stream.ts
@@ -11,6 +11,7 @@ export interface PreviewStreamState {
 	itemsReady: Record<string, BatchPreviewItem>;
 	isComplete: boolean;
 	error: string | null;
+	errorRetryable: boolean;
 	elapsedMs: number | null;
 }
 
@@ -21,6 +22,7 @@ const initial: PreviewStreamState = {
 	itemsReady: {},
 	isComplete: false,
 	error: null,
+	errorRetryable: false,
 	elapsedMs: null,
 };
 
@@ -61,6 +63,8 @@ export function useBatchPreviewStream(previewId: string | null) {
 					setState((s) => ({
 						...s,
 						itemsReady: { ...s.itemsReady, [data.item.itemId]: data.item },
+						completed: data.completed ?? s.completed,
+						total: data.total ?? s.total,
 					}));
 				}
 			} catch {
@@ -81,12 +85,15 @@ export function useBatchPreviewStream(previewId: string | null) {
 
 		es.addEventListener('error', (ev) => {
 			let msg = 'SSE connection error';
+			let retryable = true;
 			try {
-				msg = JSON.parse((ev as MessageEvent).data)?.message ?? msg;
+				const data = JSON.parse((ev as MessageEvent).data);
+				msg = data?.message ?? msg;
+				retryable = data?.retryable ?? true;
 			} catch {
-				/* network error event has no data */
+				/* network error event has no data — treat as retryable */
 			}
-			setState((s) => ({ ...s, error: msg, isComplete: true }));
+			setState((s) => ({ ...s, error: msg, errorRetryable: retryable, isComplete: true }));
 			es.close();
 		});
 

--- a/app/admin/ai-profiles/reference-pool/import-from-ghost-sheet.tsx
+++ b/app/admin/ai-profiles/reference-pool/import-from-ghost-sheet.tsx
@@ -85,7 +85,7 @@ export function ImportFromGhostSheet({ open, onOpenChange }: ImportFromGhostShee
 	});
 
 	const items = listQuery.data?.items ?? [];
-	const total = listQuery.data?.total ?? 0;
+	const total = listQuery.data?.meta?.totalItems ?? 0;
 	const totalPages = Math.max(1, Math.ceil(total / PAGE_LIMIT));
 
 	const importMutation = useMutation({

--- a/app/api/admin-proxy/[...path]/route.ts
+++ b/app/api/admin-proxy/[...path]/route.ts
@@ -156,8 +156,6 @@ async function proxyRequest(request: NextRequest, { params }: { params: { path: 
 		}
 	}
 
-	const responseBody = await backendRes.arrayBuffer();
-
 	const responseHeaders = new Headers();
 	backendRes.headers.forEach((value, key) => {
 		const lower = key.toLowerCase();
@@ -165,6 +163,19 @@ async function proxyRequest(request: NextRequest, { params }: { params: { path: 
 		responseHeaders.set(key, value);
 	});
 
+	const backendContentType = backendRes.headers.get('content-type') ?? '';
+	const isStream = backendContentType.includes('text/event-stream');
+
+	if (isStream && backendRes.body) {
+		responseHeaders.set('cache-control', 'no-cache, no-transform');
+		responseHeaders.set('x-accel-buffering', 'no');
+		return new NextResponse(backendRes.body, {
+			status: backendRes.status,
+			headers: responseHeaders,
+		});
+	}
+
+	const responseBody = await backendRes.arrayBuffer();
 	const resBody = backendRes.status === 204 ? null : responseBody;
 
 	return new NextResponse(resBody, {

--- a/app/services/admin/ghost-injection.ts
+++ b/app/services/admin/ghost-injection.ts
@@ -41,6 +41,11 @@ import type {
 	BackfillProfilesResult,
 	RegeneratePhotosBody,
 	RegeneratePhotosResult,
+	BatchPreviewRoot,
+	BatchPreviewItem,
+	CreateBatchPreviewBody,
+	PatchBatchPreviewItemBody,
+	ConfirmBatchPreviewBody,
 } from '@/app/types/ghost-injection';
 
 const BASE = '/admin/ghost-injection';
@@ -132,6 +137,32 @@ export const ghostInjection = {
 	// ─── 백필 ──────────────────────────────────────────────
 	backfillProfiles: (body: BackfillProfilesBody) =>
 		adminPost<BackfillProfilesResult>(`${BASE}/backfill-profiles`, body),
+
+	// ─── Batch preview (sequential prompt) ────────────────
+	createBatchPreview: (body: CreateBatchPreviewBody) =>
+		adminPost<BatchPreviewRoot>(`${BASE}/batch-preview`, body),
+
+	getBatchPreview: (previewId: string) =>
+		adminGet<BatchPreviewRoot>(`${BASE}/batch-preview/${previewId}`),
+
+	patchBatchPreviewItem: (
+		previewId: string,
+		itemId: string,
+		body: PatchBatchPreviewItemBody,
+	) =>
+		adminPatch<BatchPreviewItem>(
+			`${BASE}/batch-preview/${previewId}/items/${itemId}`,
+			body,
+		),
+
+	confirmBatchPreview: (previewId: string, body: ConfirmBatchPreviewBody) =>
+		adminPost<BatchCreateResult>(
+			`${BASE}/batch-preview/${previewId}/confirm`,
+			body,
+		),
+
+	deleteBatchPreview: (previewId: string) =>
+		adminDelete<void>(`${BASE}/batch-preview/${previewId}`),
 };
 
 export type GhostInjectionService = typeof ghostInjection;

--- a/app/types/ghost-injection.ts
+++ b/app/types/ghost-injection.ts
@@ -215,7 +215,7 @@ export interface BatchCreateResultItem {
 	name: string;
 	age: number;
 	mbti: string;
-	rank: GhostRank;
+	rank: UserRank;
 	introduction: string | null;
 	university: { id: string; name: string } | null;
 	department: { id: string; name: string } | null;
@@ -463,7 +463,7 @@ export interface PromoteFromGhostResult {
 
 // ─── Real User Import (F5) ──────────────────────────────
 
-export type UserRank = 'S' | 'A' | 'B' | 'C';
+export type UserRank = 'S' | 'A' | 'B' | 'C' | 'UNKNOWN';
 
 export interface RealUserPhotoItem {
 	imageId: string;
@@ -563,7 +563,7 @@ export interface BatchPreviewItem {
 		name: string;
 		age: number;
 		mbti: string;
-		rank: 'S' | 'A' | 'B' | 'C' | null;
+		rank: UserRank;
 		introduction: string;
 		keywords: string[];
 	};

--- a/app/types/ghost-injection.ts
+++ b/app/types/ghost-injection.ts
@@ -542,3 +542,68 @@ export interface BackfillProfilesResult {
 		error?: string;
 	}>;
 }
+
+// ─── Batch preview (sequential prompt flow) ──────────────
+
+export interface BatchPreviewSlotPrompt {
+	slotIndex: 0 | 1 | 2;
+	prompt: string;
+	negativePrompt?: string;
+	referenceUrls?: string[];
+	generationContext: {
+		personaDescriptor: string;
+		sceneDescriptor: string;
+		priorSlotSummaries: string[];
+	};
+}
+
+export interface BatchPreviewItem {
+	itemId: string;
+	profile: {
+		name: string;
+		age: number;
+		mbti: string;
+		rank: 'S' | 'A' | 'B' | 'C' | null;
+		introduction: string;
+		keywords: string[];
+	};
+	university: { id: string; name: string };
+	department: { id: string; name: string };
+	archetype: { id: string | null; name: string | null; traits: string[] };
+	slotPrompts: BatchPreviewSlotPrompt[];
+}
+
+export interface BatchPreviewRoot {
+	previewId: string;
+	actorUserId: string;
+	schemaContext: 'kr' | 'jp';
+	vendor: ImageVendor;
+	count: number;
+	createdAt: string;
+	expiresAt: string;
+	items: Record<string, BatchPreviewItem>;
+}
+
+export interface CreateBatchPreviewBody {
+	count: number;
+	vendor?: ImageVendor;
+	ageHint?: { min: number; max: number };
+	dryRun?: boolean;
+}
+
+export type PatchBatchPreviewItemBody =
+	| {
+			action: 'edit';
+			slotPrompts: Array<{
+				slotIndex: 0 | 1 | 2;
+				prompt: string;
+				negativePrompt?: string;
+			}>;
+	  }
+	| { action: 'regenerate'; preserveProfile?: boolean };
+
+export interface ConfirmBatchPreviewBody {
+	itemIds: string[];
+	reason: string;
+	concurrency?: number;
+}

--- a/e2e/admin-ghost-preview.spec.ts
+++ b/e2e/admin-ghost-preview.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || 'admin@test.com';
+const ADMIN_PASSWORD = process.env.E2E_ADMIN_PASSWORD || 'admin1234';
+const GHOSTS_URL = '/admin/ai-profiles/ghosts?view=card';
+const PREVIEW_REASON = 'E2E 자동화 테스트 preview 검증 플로우';
+
+async function login(page: Page) {
+	await page.goto('/');
+	await page.fill('input[type="email"]', ADMIN_EMAIL);
+	await page.fill('input[type="password"]', ADMIN_PASSWORD);
+	await page.click('button[type="submit"]');
+	await page.waitForURL('**/admin/**', { timeout: 20_000 });
+}
+
+async function gotoGhostsList(page: Page) {
+	await page.goto(GHOSTS_URL);
+	await page
+		.waitForLoadState('networkidle', { timeout: 15_000 })
+		.catch(() => undefined);
+	await expect(
+		page.getByRole('heading', { name: /가상 프로필 관리/ }),
+	).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Admin Ghost Preview Flow', () => {
+	test.setTimeout(600_000);
+
+	test('로그인 → 카드 뷰 진입', async ({ page }) => {
+		await login(page);
+		await gotoGhostsList(page);
+	});
+
+	test('프로필 생성 버튼 → preview setup 다이얼로그 오픈', async ({ page }) => {
+		await login(page);
+		await gotoGhostsList(page);
+
+		await page.getByRole('button', { name: /^프로필 생성$/ }).click();
+
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+		// Setup phase heading (matches SetupPhase h2)
+		await expect(
+			dialog.getByRole('heading', { name: /가상 프로필 미리보기 생성/ }),
+		).toBeVisible({ timeout: 5_000 });
+
+		// Setup phase controls: count input + submit button
+		await expect(dialog.locator('input[type="number"]').first()).toBeVisible();
+		await expect(
+			dialog.getByRole('button', { name: /\d+개 미리보기 생성/ }),
+		).toBeVisible();
+	});
+
+	test('preview 생성 (count=2) → review 카드 표시 → 취소', async ({ page }) => {
+		await login(page);
+		await gotoGhostsList(page);
+
+		await page.getByRole('button', { name: /^프로필 생성$/ }).click();
+
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible({ timeout: 5_000 });
+		await expect(
+			dialog.getByRole('heading', { name: /가상 프로필 미리보기 생성/ }),
+		).toBeVisible();
+
+		// Fill count=2
+		const countInput = dialog.locator('input[type="number"]').first();
+		await countInput.fill('2');
+
+		// Submit setup → triggers createBatchPreview (Gemini calls, long wait)
+		await dialog
+			.getByRole('button', { name: /\d+개 미리보기 생성/ })
+			.click();
+
+		// Wait for review phase heading
+		await expect(
+			dialog.getByRole('heading', { name: /프로필 미리보기 검토/ }),
+		).toBeVisible({ timeout: 180_000 });
+
+		// Verify total badge shows 2
+		await expect(dialog.getByText(/총\s*2\s*개/)).toBeVisible({
+			timeout: 5_000,
+		});
+
+		// Fill reason (>= 10 chars) so eventual actions satisfy validation
+		const reasonInput = dialog.locator('textarea[placeholder*="변경 사유"]');
+		await reasonInput.fill(PREVIEW_REASON);
+
+		// Click "취소 (미리보기 삭제)" → deleteBatchPreview → dialog closes on success
+		await dialog
+			.getByRole('button', { name: /취소.*미리보기 삭제/ })
+			.click();
+
+		await expect(dialog).toBeHidden({ timeout: 15_000 });
+	});
+});


### PR DESCRIPTION
## Summary
- "프로필 생성" 플로우를 단일 단계 → 4단계 다이얼로그로 전환 (setup → review → confirming → result)
- 각 고스트 카드: 3 슬롯 프롬프트 개별 편집 (Save) · 재생성 (Regenerate) · 확정 체크박스
- 선택한 itemIds 만 확정 생성 (부분 선택 가능)
- BE 브랜치 \`feat/ghost-batch-preview\` 의 5개 신규 엔드포인트 연결
- PRD: \`requirements/ghost-sequential-prompt-preview-prd.md\`

## 주요 변경
- \`app/types/ghost-injection.ts\` — preview 타입 6종 추가
- \`app/services/admin/ghost-injection.ts\` — createBatchPreview / getBatchPreview / patchBatchPreviewItem / confirmBatchPreview / deleteBatchPreview
- \`ghost-batch-preview-dialog.tsx\` (신규) — 4-phase state machine + React Query mutations
- \`ghost-preview-card.tsx\` (신규) — Collapsible 슬롯 편집 UI
- \`ghost-batch-create-dialog.tsx\` — ResultPhase / toEditableCard 재사용 export
- \`ghosts-client.tsx\` — GhostBatchCreateDialog → GhostBatchPreviewDialog 교체

## Dependencies
- BE PR #256 먼저 머지 + 배포 완료 필요 (엔드포인트 부재 시 404)
- Server-side feature flag \`ADMIN_GHOST_PREVIEW_FLOW\` 활성화 필요

## Test plan
- [ ] pnpm build 타입체크 통과
- [ ] 수동: BE 배포 후 \`/admin/ai-profiles/ghosts\` → "프로필 생성" → count=3 → preview 카드 3개 표시 확인
- [ ] 슬롯 프롬프트 편집 + Save → UI 업데이트 확인
- [ ] 단일 카드 Regenerate → 다른 persona 로 교체 확인
- [ ] 일부 체크 → Confirm → 실제 Ghost 생성 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)