### PR TITLE
feat(admin): add community automation admin UI (5 sections)

### DIFF
--- a/app/admin/community-automation/campaigns/page.tsx
+++ b/app/admin/community-automation/campaigns/page.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+	Alert,
+	Box,
+	Button,
+	Chip,
+	CircularProgress,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	FormControl,
+	InputLabel,
+	MenuItem,
+	Paper,
+	Select,
+	Table,
+	TableBody,
+	TableCell,
+	TableContainer,
+	TableHead,
+	TableRow,
+	TextField,
+	Typography,
+} from '@mui/material';
+import type {
+	Campaign,
+	CampaignStatus,
+	CreateCampaignBody,
+	DagTemplateId,
+} from '@/app/services/admin/community-automation';
+import { campaigns as campaignsApi } from '@/app/services/admin/community-automation';
+
+const STATUS_COLOR: Record<CampaignStatus, 'default' | 'success' | 'warning' | 'error'> = {
+	draft: 'default',
+	active: 'success',
+	paused: 'warning',
+	archived: 'error',
+};
+
+const STATUS_LABEL: Record<CampaignStatus, string> = {
+	draft: '초안',
+	active: '활성',
+	paused: '일시정지',
+	archived: '보관',
+};
+
+const DAG_TEMPLATES: DagTemplateId[] = ['post', 'auto_comment', 'target_comment', 'reply'];
+
+function formatDate(iso: string | null) {
+	if (!iso) return '-';
+	return new Date(iso).toLocaleDateString('ko-KR');
+}
+
+export default function CampaignsPage() {
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [items, setItems] = useState<Campaign[]>([]);
+	const [statusFilter, setStatusFilter] = useState<CampaignStatus | ''>('');
+
+	const [createOpen, setCreateOpen] = useState(false);
+	const [createForm, setCreateForm] = useState<CreateCampaignBody>({ name: '', category: '' });
+	const [createLoading, setCreateLoading] = useState(false);
+
+	const [dagOpen, setDagOpen] = useState<string | null>(null);
+	const [dagCount, setDagCount] = useState(1);
+	const [dagTemplate, setDagTemplate] = useState<DagTemplateId | ''>('');
+	const [dagLoading, setDagLoading] = useState(false);
+
+	const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+	const load = useCallback(async () => {
+		setLoading(true);
+		setError(null);
+		try {
+			const data = await campaignsApi.list(statusFilter ? { status: statusFilter } : undefined);
+			setItems(data);
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : '불러오기 실패');
+		} finally {
+			setLoading(false);
+		}
+	}, [statusFilter]);
+
+	useEffect(() => {
+		load();
+	}, [load]);
+
+	async function handleCreate() {
+		if (!createForm.name || !createForm.category) return;
+		setCreateLoading(true);
+		try {
+			await campaignsApi.create(createForm);
+			setCreateOpen(false);
+			setCreateForm({ name: '', category: '' });
+			await load();
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : '생성 실패');
+		} finally {
+			setCreateLoading(false);
+		}
+	}
+
+	async function handleStatusChange(id: string, action: 'activate' | 'pause' | 'archive') {
+		setActionLoading(id + action);
+		try {
+			await campaignsApi[action](id);
+			await load();
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : '상태 변경 실패');
+		} finally {
+			setActionLoading(null);
+		}
+	}
+
+	async function handleDagRun() {
+		if (!dagOpen) return;
+		setDagLoading(true);
+		try {
+			const result = await campaignsApi.triggerDagRun(dagOpen, {
+				count: dagCount,
+				dagTemplateId: dagTemplate || undefined,
+			});
+			alert(`DAG ${result.jobsEnqueued}개 큐 등록 완료`);
+			setDagOpen(null);
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : 'DAG 실행 실패');
+		} finally {
+			setDagLoading(false);
+		}
+	}
+
+	function getNextActions(status: CampaignStatus): Array<'activate' | 'pause' | 'archive'> {
+		if (status === 'draft') return ['activate', 'archive'];
+		if (status === 'active') return ['pause', 'archive'];
+		if (status === 'paused') return ['activate', 'archive'];
+		return [];
+	}
+
+	return (
+		<Box>
+			<Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+				<Box display="flex" gap={2} alignItems="center">
+					<FormControl size="small" sx={{ minWidth: 140 }}>
+						<InputLabel>상태 필터</InputLabel>
+						<Select
+							value={statusFilter}
+							label="상태 필터"
+							onChange={(e) => setStatusFilter(e.target.value as CampaignStatus | '')}
+						>
+							<MenuItem value="">전체</MenuItem>
+							{(Object.keys(STATUS_LABEL) as CampaignStatus[]).map((s) => (
+								<MenuItem key={s} value={s}>{STATUS_LABEL[s]}</MenuItem>
+							))}
+						</Select>
+					</FormControl>
+				</Box>
+				<Button variant="contained" onClick={() => setCreateOpen(true)}>
+					캠페인 생성
+				</Button>
+			</Box>
+
+			{error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+
+			{loading ? (
+				<Box display="flex" justifyContent="center" py={6}>
+					<CircularProgress />
+				</Box>
+			) : (
+				<TableContainer component={Paper}>
+					<Table size="small">
+						<TableHead>
+							<TableRow>
+								<TableCell>이름</TableCell>
+								<TableCell>카테고리</TableCell>
+								<TableCell>상태</TableCell>
+								<TableCell>DAG 템플릿</TableCell>
+								<TableCell>시작</TableCell>
+								<TableCell>종료</TableCell>
+								<TableCell>생성일</TableCell>
+								<TableCell align="right">액션</TableCell>
+							</TableRow>
+						</TableHead>
+						<TableBody>
+							{items.length === 0 ? (
+								<TableRow>
+									<TableCell colSpan={8} align="center">캠페인 없음</TableCell>
+								</TableRow>
+							) : items.map((item) => (
+								<TableRow key={item.id} hover>
+									<TableCell>
+										<Typography variant="body2" fontWeight={500}>{item.name}</Typography>
+										<Typography variant="caption" color="text.secondary">{item.id.slice(0, 8)}…</Typography>
+									</TableCell>
+									<TableCell>{item.category}</TableCell>
+									<TableCell>
+										<Chip
+											label={STATUS_LABEL[item.status]}
+											color={STATUS_COLOR[item.status]}
+											size="small"
+										/>
+									</TableCell>
+									<TableCell>{item.dagTemplateId ?? '-'}</TableCell>
+									<TableCell>{formatDate(item.startAt)}</TableCell>
+									<TableCell>{formatDate(item.endAt)}</TableCell>
+									<TableCell>{formatDate(item.createdAt)}</TableCell>
+									<TableCell align="right">
+										<Box display="flex" gap={0.5} justifyContent="flex-end">
+											{getNextActions(item.status).map((action) => (
+												<Button
+													key={action}
+													size="small"
+													variant="outlined"
+													disabled={actionLoading === item.id + action}
+													onClick={() => handleStatusChange(item.id, action)}
+												>
+													{action === 'activate' ? '활성화' : action === 'pause' ? '일시정지' : '보관'}
+												</Button>
+											))}
+											{item.status !== 'archived' && (
+												<Button
+													size="small"
+													variant="contained"
+													color="secondary"
+													onClick={() => setDagOpen(item.id)}
+												>
+													DAG 실행
+												</Button>
+											)}
+										</Box>
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</TableContainer>
+			)}
+
+			{/* Create Dialog */}
+			<Dialog open={createOpen} onClose={() => setCreateOpen(false)} maxWidth="sm" fullWidth>
+				<DialogTitle>캠페인 생성</DialogTitle>
+				<DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: '16px !important' }}>
+					<TextField
+						label="이름"
+						required
+						value={createForm.name}
+						onChange={(e) => setCreateForm((f) => ({ ...f, name: e.target.value }))}
+					/>
+					<TextField
+						label="카테고리"
+						required
+						value={createForm.category}
+						onChange={(e) => setCreateForm((f) => ({ ...f, category: e.target.value }))}
+					/>
+					<FormControl>
+						<InputLabel>DAG 템플릿</InputLabel>
+						<Select
+							value={createForm.dagTemplateId ?? ''}
+							label="DAG 템플릿"
+							onChange={(e) =>
+								setCreateForm((f) => ({ ...f, dagTemplateId: (e.target.value as DagTemplateId) || undefined }))
+							}
+						>
+							<MenuItem value="">기본값 (post)</MenuItem>
+							{DAG_TEMPLATES.map((t) => <MenuItem key={t} value={t}>{t}</MenuItem>)}
+						</Select>
+					</FormControl>
+					<TextField
+						label="시작일 (ISO8601)"
+						placeholder="2026-05-01T00:00:00Z"
+						value={createForm.startAt ?? ''}
+						onChange={(e) => setCreateForm((f) => ({ ...f, startAt: e.target.value || undefined }))}
+					/>
+					<TextField
+						label="종료일 (ISO8601)"
+						placeholder="2026-06-01T00:00:00Z"
+						value={createForm.endAt ?? ''}
+						onChange={(e) => setCreateForm((f) => ({ ...f, endAt: e.target.value || undefined }))}
+					/>
+				</DialogContent>
+				<DialogActions>
+					<Button onClick={() => setCreateOpen(false)}>취소</Button>
+					<Button variant="contained" disabled={createLoading} onClick={handleCreate}>
+						{createLoading ? <CircularProgress size={16} /> : '생성'}
+					</Button>
+				</DialogActions>
+			</Dialog>
+
+			{/* DAG Run Dialog */}
+			<Dialog open={!!dagOpen} onClose={() => setDagOpen(null)} maxWidth="xs" fullWidth>
+				<DialogTitle>DAG 수동 실행</DialogTitle>
+				<DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: '16px !important' }}>
+					<FormControl>
+						<InputLabel>DAG 템플릿</InputLabel>
+						<Select
+							value={dagTemplate}
+							label="DAG 템플릿"
+							onChange={(e) => setDagTemplate(e.target.value as DagTemplateId | '')}
+						>
+							<MenuItem value="">캠페인 기본값</MenuItem>
+							{DAG_TEMPLATES.map((t) => <MenuItem key={t} value={t}>{t}</MenuItem>)}
+						</Select>
+					</FormControl>
+					<TextField
+						label="실행 수 (1-10)"
+						type="number"
+						inputProps={{ min: 1, max: 10 }}
+						value={dagCount}
+						onChange={(e) => setDagCount(Math.max(1, Math.min(10, Number(e.target.value))))}
+					/>
+				</DialogContent>
+				<DialogActions>
+					<Button onClick={() => setDagOpen(null)}>취소</Button>
+					<Button variant="contained" disabled={dagLoading} onClick={handleDagRun}>
+						{dagLoading ? <CircularProgress size={16} /> : '실행'}
+					</Button>
+				</DialogActions>
+			</Dialog>
+		</Box>
+	);
+}

--- a/app/admin/community-automation/layout.tsx
+++ b/app/admin/community-automation/layout.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+import { Box, Tab, Tabs, Typography } from '@mui/material';
+
+const TABS = [
+	{ label: '캠페인', path: '/admin/community-automation/campaigns' },
+	{ label: '검수 큐', path: '/admin/community-automation/review-queue' },
+	{ label: '메트릭스', path: '/admin/community-automation/metrics' },
+	{ label: '페르소나', path: '/admin/community-automation/personas' },
+	{ label: '설정', path: '/admin/community-automation/settings' },
+];
+
+export default function CommunityAutomationLayout({ children }: { children: React.ReactNode }) {
+	const pathname = usePathname();
+	const router = useRouter();
+
+	const currentTab = TABS.findIndex((t) => pathname.startsWith(t.path));
+
+	return (
+		<Box sx={{ p: 3 }}>
+			<Typography variant="h5" fontWeight={700} mb={2}>
+				커뮤니티 자동화
+			</Typography>
+			<Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}>
+				<Tabs value={currentTab === -1 ? 0 : currentTab} onChange={(_, v) => router.push(TABS[v].path)}>
+					{TABS.map((t) => (
+						<Tab key={t.path} label={t.label} />
+					))}
+				</Tabs>
+			</Box>
+			{children}
+		</Box>
+	);
+}

--- a/app/admin/community-automation/metrics/page.tsx
+++ b/app/admin/community-automation/metrics/page.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+	Alert,
+	Box,
+	Card,
+	CardContent,
+	CircularProgress,
+	Divider,
+	Grid,
+	Paper,
+	Table,
+	TableBody,
+	TableCell,
+	TableContainer,
+	TableHead,
+	TableRow,
+	TextField,
+	Typography,
+} from '@mui/material';
+import type { MetricsSummary, QueueDepth } from '@/app/services/admin/community-automation';
+import { metrics as metricsApi } from '@/app/services/admin/community-automation';
+
+function StatCard({ label, value, color }: { label: string; value: number; color?: string }) {
+	return (
+		<Card variant="outlined">
+			<CardContent>
+				<Typography variant="caption" color="text.secondary">{label}</Typography>
+				<Typography variant="h4" fontWeight={700} color={color ?? 'text.primary'}>{value}</Typography>
+			</CardContent>
+		</Card>
+	);
+}
+
+export default function MetricsPage() {
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [summary, setSummary] = useState<MetricsSummary | null>(null);
+	const [depth, setDepth] = useState<QueueDepth | null>(null);
+
+	const today = new Date();
+	const thirtyDaysAgo = new Date(today);
+	thirtyDaysAgo.setDate(today.getDate() - 30);
+
+	const [from, setFrom] = useState(thirtyDaysAgo.toISOString().split('T')[0]);
+	const [to, setTo] = useState(today.toISOString().split('T')[0]);
+
+	const load = useCallback(async () => {
+		setLoading(true);
+		setError(null);
+		try {
+			const [s, d] = await Promise.all([
+				metricsApi.summary(from ? `${from}T00:00:00Z` : undefined, to ? `${to}T23:59:59Z` : undefined),
+				metricsApi.queueDepth(),
+			]);
+			setSummary(s);
+			setDepth(d);
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : '불러오기 실패');
+		} finally {
+			setLoading(false);
+		}
+	}, [from, to]);
+
+	useEffect(() => {
+		load();
+	}, [load]);
+
+	return (
+		<Box>
+			<Box display="flex" gap={2} alignItems="center" mb={3}>
+				<TextField
+					label="시작일"
+					type="date"
+					size="small"
+					InputLabelProps={{ shrink: true }}
+					value={from}
+					onChange={(e) => setFrom(e.target.value)}
+				/>
+				<TextField
+					label="종료일"
+					type="date"
+					size="small"
+					InputLabelProps={{ shrink: true }}
+					value={to}
+					onChange={(e) => setTo(e.target.value)}
+				/>
+			</Box>
+
+			{error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+
+			{loading ? (
+				<Box display="flex" justifyContent="center" py={6}>
+					<CircularProgress />
+				</Box>
+			) : summary && depth ? (
+				<>
+					<Typography variant="h6" mb={1}>전체 현황</Typography>
+					<Grid container spacing={2} mb={3}>
+						<Grid item xs={6} sm={3}>
+							<StatCard label="발화됨" value={summary.totalPublished} color="success.main" />
+						</Grid>
+						<Grid item xs={6} sm={3}>
+							<StatCard label="검수 대기" value={summary.totalPendingReview} color="warning.main" />
+						</Grid>
+						<Grid item xs={6} sm={3}>
+							<StatCard label="거절됨" value={summary.totalRejected} color="error.main" />
+						</Grid>
+						<Grid item xs={6} sm={3}>
+							<StatCard label="회수됨" value={summary.totalWithdrawn} />
+						</Grid>
+					</Grid>
+
+					<Typography variant="h6" mb={1}>큐 깊이</Typography>
+					<Grid container spacing={2} mb={3}>
+						<Grid item xs={6} sm={3}>
+							<StatCard label="검수 대기" value={depth.pending_review} color="warning.main" />
+						</Grid>
+						<Grid item xs={6} sm={3}>
+							<StatCard label="예약됨" value={depth.scheduled} color="info.main" />
+						</Grid>
+						<Grid item xs={6} sm={3}>
+							<StatCard label="초안" value={depth.draft} />
+						</Grid>
+						<Grid item xs={6} sm={3}>
+							<StatCard label="품질 실패" value={depth.quality_failed} color="error.main" />
+						</Grid>
+					</Grid>
+
+					<Divider sx={{ my: 2 }} />
+
+					<Typography variant="h6" mb={1}>상태별 콘텐츠 수</Typography>
+					<TableContainer component={Paper} sx={{ mb: 3 }}>
+						<Table size="small">
+							<TableHead>
+								<TableRow>
+									<TableCell>상태</TableCell>
+									<TableCell align="right">수량</TableCell>
+								</TableRow>
+							</TableHead>
+							<TableBody>
+								{summary.contentByStatus.map((row) => (
+									<TableRow key={row.status}>
+										<TableCell>{row.status}</TableCell>
+										<TableCell align="right">{row.count}</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					</TableContainer>
+
+					<Typography variant="h6" mb={1}>일별 통계</Typography>
+					<TableContainer component={Paper}>
+						<Table size="small">
+							<TableHead>
+								<TableRow>
+									<TableCell>날짜</TableCell>
+									<TableCell align="right">발화됨</TableCell>
+									<TableCell align="right">거절됨</TableCell>
+									<TableCell align="right">회수됨</TableCell>
+								</TableRow>
+							</TableHead>
+							<TableBody>
+								{summary.dailyStats.length === 0 ? (
+									<TableRow>
+										<TableCell colSpan={4} align="center">데이터 없음</TableCell>
+									</TableRow>
+								) : summary.dailyStats.map((row) => (
+									<TableRow key={row.date}>
+										<TableCell>{row.date}</TableCell>
+										<TableCell align="right">{row.published}</TableCell>
+										<TableCell align="right">{row.rejected}</TableCell>
+										<TableCell align="right">{row.withdrawn}</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					</TableContainer>
+				</>
+			) : null}
+		</Box>
+	);
+}

--- a/app/admin/community-automation/page.tsx
+++ b/app/admin/community-automation/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function CommunityAutomationPage() {
+	redirect('/admin/community-automation/campaigns');
+}

--- a/app/admin/community-automation/personas/page.tsx
+++ b/app/admin/community-automation/personas/page.tsx
@@ -1,0 +1,290 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+	Alert,
+	Box,
+	Button,
+	Card,
+	CardContent,
+	Chip,
+	CircularProgress,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	Divider,
+	FormControl,
+	Grid,
+	InputLabel,
+	MenuItem,
+	Paper,
+	Select,
+	Slider,
+	Table,
+	TableBody,
+	TableCell,
+	TableContainer,
+	TableHead,
+	TableRow,
+	Typography,
+} from '@mui/material';
+import type {
+	GhostPersonaInfo,
+	PersonaDiversityReport,
+	CommunityTraits,
+	ReactionSpeed,
+	ActivityCurve,
+} from '@/app/services/admin/community-automation';
+import { personas as personasApi } from '@/app/services/admin/community-automation';
+
+export default function PersonasPage() {
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [items, setItems] = useState<GhostPersonaInfo[]>([]);
+	const [diversity, setDiversity] = useState<PersonaDiversityReport | null>(null);
+
+	const [traitTarget, setTraitTarget] = useState<string | null>(null);
+	const [traitForm, setTraitForm] = useState<CommunityTraits>({});
+	const [traitLoading, setTraitLoading] = useState(false);
+
+	const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+	const [deleteLoading, setDeleteLoading] = useState(false);
+
+	const load = useCallback(async () => {
+		setLoading(true);
+		setError(null);
+		try {
+			const [list, div] = await Promise.all([
+				personasApi.list(),
+				personasApi.diversity(),
+			]);
+			setItems(list);
+			setDiversity(div);
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : '불러오기 실패');
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		load();
+	}, [load]);
+
+	function openTraitDialog(persona: GhostPersonaInfo) {
+		setTraitTarget(persona.id);
+		setTraitForm({ ...persona.communityTraits });
+	}
+
+	async function handleTraitSave() {
+		if (!traitTarget) return;
+		setTraitLoading(true);
+		try {
+			await personasApi.setTraits(traitTarget, traitForm);
+			setTraitTarget(null);
+			await load();
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : '트레이트 저장 실패');
+		} finally {
+			setTraitLoading(false);
+		}
+	}
+
+	async function handleTraitDelete() {
+		if (!deleteTarget) return;
+		setDeleteLoading(true);
+		try {
+			await personasApi.deleteTraits(deleteTarget);
+			setDeleteTarget(null);
+			await load();
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : '트레이트 삭제 실패');
+		} finally {
+			setDeleteLoading(false);
+		}
+	}
+
+	return (
+		<Box>
+			{error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+
+			{loading ? (
+				<Box display="flex" justifyContent="center" py={6}>
+					<CircularProgress />
+				</Box>
+			) : (
+				<>
+					{diversity && (
+						<>
+							<Typography variant="h6" mb={1}>다양성 리포트</Typography>
+							<Grid container spacing={2} mb={3}>
+								<Grid item xs={6} sm={3}>
+									<Card variant="outlined">
+										<CardContent>
+											<Typography variant="caption" color="text.secondary">활성 Ghost</Typography>
+											<Typography variant="h4" fontWeight={700}>{diversity.totalActiveGhosts}</Typography>
+										</CardContent>
+									</Card>
+								</Grid>
+								<Grid item xs={6} sm={3}>
+									<Card variant="outlined">
+										<CardContent>
+											<Typography variant="caption" color="text.secondary">다양성 점수</Typography>
+											<Typography variant="h4" fontWeight={700} color="success.main">
+												{diversity.diversityScore.toFixed(2)}
+											</Typography>
+										</CardContent>
+									</Card>
+								</Grid>
+							</Grid>
+
+							<Typography variant="subtitle2" mb={1}>아키타입 분포</Typography>
+							<TableContainer component={Paper} sx={{ mb: 3 }}>
+								<Table size="small">
+									<TableHead>
+										<TableRow>
+											<TableCell>아키타입 코드</TableCell>
+											<TableCell align="right">수량</TableCell>
+											<TableCell align="right">비율 (%)</TableCell>
+										</TableRow>
+									</TableHead>
+									<TableBody>
+										{diversity.archetypeDistribution.map((row) => (
+											<TableRow key={row.archetypeCode}>
+												<TableCell>{row.archetypeCode}</TableCell>
+												<TableCell align="right">{row.count}</TableCell>
+												<TableCell align="right">{row.percentage.toFixed(1)}</TableCell>
+											</TableRow>
+										))}
+									</TableBody>
+								</Table>
+							</TableContainer>
+							<Divider sx={{ my: 2 }} />
+						</>
+					)}
+
+					<Typography variant="h6" mb={1}>Ghost 페르소나 목록</Typography>
+					<TableContainer component={Paper}>
+						<Table size="small">
+							<TableHead>
+								<TableRow>
+									<TableCell>아키타입</TableCell>
+									<TableCell>상태</TableCell>
+									<TableCell>반응 속도</TableCell>
+									<TableCell>노이즈 강도</TableCell>
+									<TableCell>활동 커브</TableCell>
+									<TableCell align="right">트레이트</TableCell>
+								</TableRow>
+							</TableHead>
+							<TableBody>
+								{items.length === 0 ? (
+									<TableRow>
+										<TableCell colSpan={6} align="center">활성 Ghost 없음</TableCell>
+									</TableRow>
+								) : items.map((p) => (
+									<TableRow key={p.id} hover>
+										<TableCell>
+											<Typography variant="body2" fontWeight={500}>{p.archetypeName}</Typography>
+											<Typography variant="caption" color="text.secondary">{p.archetypeCode}</Typography>
+										</TableCell>
+										<TableCell>
+											<Chip label={p.status} size="small" color={p.status === 'ACTIVE' ? 'success' : 'default'} />
+										</TableCell>
+										<TableCell>{p.communityTraits.reactionSpeed ?? '-'}</TableCell>
+										<TableCell>{p.communityTraits.noiseStrength ?? '-'}</TableCell>
+										<TableCell>{p.communityTraits.activityCurve ?? '-'}</TableCell>
+										<TableCell align="right">
+											<Box display="flex" gap={0.5} justifyContent="flex-end">
+												<Button size="small" variant="outlined" onClick={() => openTraitDialog(p)}>
+													편집
+												</Button>
+												<Button
+													size="small"
+													variant="outlined"
+													color="error"
+													onClick={() => setDeleteTarget(p.id)}
+												>
+													초기화
+												</Button>
+											</Box>
+										</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					</TableContainer>
+				</>
+			)}
+
+			{/* Trait Edit Dialog */}
+			<Dialog open={!!traitTarget} onClose={() => setTraitTarget(null)} maxWidth="xs" fullWidth>
+				<DialogTitle>커뮤니티 트레이트 설정</DialogTitle>
+				<DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 3, pt: '16px !important' }}>
+					<FormControl size="small">
+						<InputLabel>반응 속도</InputLabel>
+						<Select
+							value={traitForm.reactionSpeed ?? ''}
+							label="반응 속도"
+							onChange={(e) => setTraitForm((f) => ({ ...f, reactionSpeed: (e.target.value as ReactionSpeed) || undefined }))}
+						>
+							<MenuItem value="">미설정</MenuItem>
+							<MenuItem value="high">빠름 (high)</MenuItem>
+							<MenuItem value="mid">보통 (mid)</MenuItem>
+							<MenuItem value="low">느림 (low)</MenuItem>
+						</Select>
+					</FormControl>
+
+					<Box>
+						<Typography variant="caption" gutterBottom display="block">
+							노이즈 강도: {traitForm.noiseStrength ?? 0}
+						</Typography>
+						<Slider
+							value={traitForm.noiseStrength ?? 0}
+							min={0}
+							max={1}
+							step={0.05}
+							valueLabelDisplay="auto"
+							onChange={(_, v) => setTraitForm((f) => ({ ...f, noiseStrength: v as number }))}
+						/>
+					</Box>
+
+					<FormControl size="small">
+						<InputLabel>활동 커브</InputLabel>
+						<Select
+							value={traitForm.activityCurve ?? ''}
+							label="활동 커브"
+							onChange={(e) => setTraitForm((f) => ({ ...f, activityCurve: (e.target.value as ActivityCurve) || undefined }))}
+						>
+							<MenuItem value="">미설정</MenuItem>
+							<MenuItem value="morning">아침 (morning)</MenuItem>
+							<MenuItem value="night">밤 (night)</MenuItem>
+							<MenuItem value="random">랜덤 (random)</MenuItem>
+						</Select>
+					</FormControl>
+				</DialogContent>
+				<DialogActions>
+					<Button onClick={() => setTraitTarget(null)}>취소</Button>
+					<Button variant="contained" disabled={traitLoading} onClick={handleTraitSave}>
+						{traitLoading ? <CircularProgress size={16} /> : '저장'}
+					</Button>
+				</DialogActions>
+			</Dialog>
+
+			{/* Delete Confirm Dialog */}
+			<Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)} maxWidth="xs">
+				<DialogTitle>트레이트 오버라이드 삭제</DialogTitle>
+				<DialogContent>
+					<Typography>이 Ghost의 커뮤니티 트레이트 오버라이드를 삭제하시겠습니까?</Typography>
+					<Typography variant="caption" color="text.secondary">재시작 시 초기화되는 설정입니다.</Typography>
+				</DialogContent>
+				<DialogActions>
+					<Button onClick={() => setDeleteTarget(null)}>취소</Button>
+					<Button variant="contained" color="error" disabled={deleteLoading} onClick={handleTraitDelete}>
+						{deleteLoading ? <CircularProgress size={16} /> : '삭제'}
+					</Button>
+				</DialogActions>
+			</Dialog>
+		</Box>
+	);
+}

--- a/app/admin/community-automation/review-queue/page.tsx
+++ b/app/admin/community-automation/review-queue/page.tsx
@@ -1,0 +1,330 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+	Alert,
+	Box,
+	Button,
+	Checkbox,
+	Chip,
+	CircularProgress,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	FormControl,
+	InputLabel,
+	MenuItem,
+	Paper,
+	Select,
+	Table,
+	TableBody,
+	TableCell,
+	TableContainer,
+	TableHead,
+	TableRow,
+	TextField,
+	Tooltip,
+	Typography,
+} from '@mui/material';
+import type { Content, ContentStatus } from '@/app/services/admin/community-automation';
+import { reviewQueue as reviewApi } from '@/app/services/admin/community-automation';
+
+const STATUS_COLOR: Record<ContentStatus, 'default' | 'warning' | 'success' | 'error' | 'info'> = {
+	draft: 'default',
+	pending_review: 'warning',
+	approved: 'info',
+	scheduled: 'info',
+	published: 'success',
+	rejected: 'error',
+	quality_failed: 'error',
+	withdrawn: 'default',
+};
+
+const STATUS_LABEL: Record<ContentStatus, string> = {
+	draft: '초안',
+	pending_review: '검수 대기',
+	approved: '승인',
+	scheduled: '예약됨',
+	published: '발화됨',
+	rejected: '거절됨',
+	quality_failed: '품질 실패',
+	withdrawn: '회수됨',
+};
+
+type DialogMode = 'reject' | 'inject' | 'withdraw' | 'regenerate' | null;
+
+export default function ReviewQueuePage() {
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [items, setItems] = useState<Content[]>([]);
+
+	const [selected, setSelected] = useState<Set<string>>(new Set());
+	const [bulkAction, setBulkAction] = useState<'approve' | 'reject' | 'withdraw'>('approve');
+	const [bulkLoading, setBulkLoading] = useState(false);
+
+	const [dialogMode, setDialogMode] = useState<DialogMode>(null);
+	const [dialogTarget, setDialogTarget] = useState<string | null>(null);
+	const [dialogText, setDialogText] = useState('');
+	const [dialogLoading, setDialogLoading] = useState(false);
+
+	const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+	const load = useCallback(async () => {
+		setLoading(true);
+		setError(null);
+		try {
+			const data = await reviewApi.list();
+			setItems(data);
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : '불러오기 실패');
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		load();
+	}, [load]);
+
+	function openDialog(mode: DialogMode, id: string, prefill = '') {
+		setDialogMode(mode);
+		setDialogTarget(id);
+		setDialogText(prefill);
+	}
+
+	async function handleDialogConfirm() {
+		if (!dialogTarget || !dialogMode) return;
+		setDialogLoading(true);
+		try {
+			if (dialogMode === 'reject') await reviewApi.reject(dialogTarget, dialogText);
+			else if (dialogMode === 'inject') await reviewApi.inject(dialogTarget, dialogText);
+			else if (dialogMode === 'withdraw') await reviewApi.withdraw(dialogTarget, dialogText);
+			else if (dialogMode === 'regenerate') await reviewApi.regenerate(dialogTarget);
+			setDialogMode(null);
+			setDialogTarget(null);
+			await load();
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : '처리 실패');
+		} finally {
+			setDialogLoading(false);
+		}
+	}
+
+	async function handleApprove(id: string) {
+		setActionLoading(id);
+		try {
+			await reviewApi.approve(id);
+			await load();
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : '승인 실패');
+		} finally {
+			setActionLoading(null);
+		}
+	}
+
+	async function handleBulk() {
+		if (selected.size === 0) return;
+		setBulkLoading(true);
+		try {
+			const result = await reviewApi.bulk({
+				contentIds: Array.from(selected),
+				action: bulkAction,
+			});
+			const msg = `완료: ${result.succeeded.length}개, 실패: ${result.failed.length}개`;
+			alert(msg);
+			setSelected(new Set());
+			await load();
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : '일괄 처리 실패');
+		} finally {
+			setBulkLoading(false);
+		}
+	}
+
+	function toggleSelect(id: string) {
+		setSelected((prev) => {
+			const next = new Set(prev);
+			next.has(id) ? next.delete(id) : next.add(id);
+			return next;
+		});
+	}
+
+	function toggleSelectAll() {
+		if (selected.size === items.length) {
+			setSelected(new Set());
+		} else {
+			setSelected(new Set(items.map((i) => i.id)));
+		}
+	}
+
+	const dialogTitle: Record<NonNullable<DialogMode>, string> = {
+		reject: '거절 사유',
+		inject: '텍스트 수정 후 승인',
+		withdraw: '회수 사유',
+		regenerate: '재생성 확인',
+	};
+
+	return (
+		<Box>
+			{error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+
+			{selected.size > 0 && (
+				<Paper sx={{ p: 2, mb: 2, display: 'flex', gap: 2, alignItems: 'center' }}>
+					<Typography variant="body2">{selected.size}개 선택됨</Typography>
+					<FormControl size="small" sx={{ minWidth: 120 }}>
+						<InputLabel>일괄 액션</InputLabel>
+						<Select
+							value={bulkAction}
+							label="일괄 액션"
+							onChange={(e) => setBulkAction(e.target.value as typeof bulkAction)}
+						>
+							<MenuItem value="approve">일괄 승인</MenuItem>
+							<MenuItem value="reject">일괄 거절</MenuItem>
+							<MenuItem value="withdraw">일괄 회수</MenuItem>
+						</Select>
+					</FormControl>
+					<Button variant="contained" disabled={bulkLoading} onClick={handleBulk}>
+						{bulkLoading ? <CircularProgress size={16} /> : '실행'}
+					</Button>
+					<Button onClick={() => setSelected(new Set())}>선택 해제</Button>
+				</Paper>
+			)}
+
+			{loading ? (
+				<Box display="flex" justifyContent="center" py={6}>
+					<CircularProgress />
+				</Box>
+			) : (
+				<TableContainer component={Paper}>
+					<Table size="small">
+						<TableHead>
+							<TableRow>
+								<TableCell padding="checkbox">
+									<Checkbox
+										indeterminate={selected.size > 0 && selected.size < items.length}
+										checked={items.length > 0 && selected.size === items.length}
+										onChange={toggleSelectAll}
+									/>
+								</TableCell>
+								<TableCell>내용 미리보기</TableCell>
+								<TableCell>타입</TableCell>
+								<TableCell>상태</TableCell>
+								<TableCell>품질 점수</TableCell>
+								<TableCell>생성일</TableCell>
+								<TableCell align="right">액션</TableCell>
+							</TableRow>
+						</TableHead>
+						<TableBody>
+							{items.length === 0 ? (
+								<TableRow>
+									<TableCell colSpan={7} align="center">검수 대기 콘텐츠 없음</TableCell>
+								</TableRow>
+							) : items.map((item) => (
+								<TableRow key={item.id} hover selected={selected.has(item.id)}>
+									<TableCell padding="checkbox">
+										<Checkbox checked={selected.has(item.id)} onChange={() => toggleSelect(item.id)} />
+									</TableCell>
+									<TableCell sx={{ maxWidth: 240 }}>
+										<Tooltip title={item.finalText ?? item.generatedText ?? ''}>
+											<Typography variant="body2" noWrap>
+												{(item.finalText ?? item.generatedText ?? '-').slice(0, 60)}
+											</Typography>
+										</Tooltip>
+									</TableCell>
+									<TableCell>{item.targetType ?? '-'}</TableCell>
+									<TableCell>
+										<Chip
+											label={STATUS_LABEL[item.status]}
+											color={STATUS_COLOR[item.status]}
+											size="small"
+										/>
+									</TableCell>
+									<TableCell>
+										{item.qualityScores
+											? Object.entries(item.qualityScores)
+												.filter(([, v]) => v !== undefined)
+												.slice(0, 2)
+												.map(([k, v]) => `${k}:${v}`)
+												.join(' | ')
+											: '-'}
+									</TableCell>
+									<TableCell>
+										{new Date(item.createdAt).toLocaleString('ko-KR', { dateStyle: 'short', timeStyle: 'short' })}
+									</TableCell>
+									<TableCell align="right">
+										<Box display="flex" gap={0.5} justifyContent="flex-end" flexWrap="wrap">
+											<Button
+												size="small"
+												variant="contained"
+												color="success"
+												disabled={actionLoading === item.id}
+												onClick={() => handleApprove(item.id)}
+											>
+												승인
+											</Button>
+											<Button
+												size="small"
+												variant="outlined"
+												onClick={() => openDialog('inject', item.id, item.finalText ?? item.generatedText ?? '')}
+											>
+												수정승인
+											</Button>
+											<Button
+												size="small"
+												variant="outlined"
+												color="error"
+												onClick={() => openDialog('reject', item.id)}
+											>
+												거절
+											</Button>
+											<Button
+												size="small"
+												variant="outlined"
+												onClick={() => openDialog('regenerate', item.id)}
+											>
+												재생성
+											</Button>
+											<Button
+												size="small"
+												variant="outlined"
+												color="warning"
+												onClick={() => openDialog('withdraw', item.id)}
+											>
+												회수
+											</Button>
+										</Box>
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</TableContainer>
+			)}
+
+			<Dialog open={!!dialogMode} onClose={() => setDialogMode(null)} maxWidth="sm" fullWidth>
+				<DialogTitle>{dialogMode ? dialogTitle[dialogMode] : ''}</DialogTitle>
+				<DialogContent sx={{ pt: '16px !important' }}>
+					{dialogMode === 'regenerate' ? (
+						<Typography>이 콘텐츠를 회수하고 새 DAG run을 시작하시겠습니까?</Typography>
+					) : (
+						<TextField
+							label={dialogMode === 'inject' ? '최종 텍스트' : '사유'}
+							multiline
+							rows={dialogMode === 'inject' ? 6 : 3}
+							fullWidth
+							value={dialogText}
+							onChange={(e) => setDialogText(e.target.value)}
+						/>
+					)}
+				</DialogContent>
+				<DialogActions>
+					<Button onClick={() => setDialogMode(null)}>취소</Button>
+					<Button variant="contained" disabled={dialogLoading} onClick={handleDialogConfirm}>
+						{dialogLoading ? <CircularProgress size={16} /> : '확인'}
+					</Button>
+				</DialogActions>
+			</Dialog>
+		</Box>
+	);
+}

--- a/app/admin/community-automation/settings/page.tsx
+++ b/app/admin/community-automation/settings/page.tsx
@@ -1,0 +1,278 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+	Alert,
+	Box,
+	Button,
+	Card,
+	CardContent,
+	Chip,
+	CircularProgress,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogTitle,
+	Divider,
+	FormControlLabel,
+	Switch,
+	TextField,
+	Typography,
+} from '@mui/material';
+import type { CommunitySettings, KillSwitchStatus } from '@/app/services/admin/community-automation';
+import { communitySettings as settingsApi } from '@/app/services/admin/community-automation';
+
+export default function SettingsPage() {
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [killSwitch, setKillSwitch] = useState<KillSwitchStatus | null>(null);
+	const [settings, setSettings] = useState<CommunitySettings | null>(null);
+
+	const [killActionLoading, setKillActionLoading] = useState(false);
+	const [killConfirmOpen, setKillConfirmOpen] = useState(false);
+	const [killConfirmAction, setKillConfirmAction] = useState<'kill' | 'restore'>('kill');
+
+	const [settingsLoading, setSettingsLoading] = useState(false);
+	const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
+	const [resetLoading, setResetLoading] = useState(false);
+
+	const [form, setForm] = useState<CommunitySettings>({
+		dagRunEnabled: true,
+		publishEnabled: true,
+		activitySimulatorEnabled: true,
+		maxDailyPublish: 50,
+		reviewRequiredBeforePublish: true,
+	});
+
+	const load = useCallback(async () => {
+		setLoading(true);
+		setError(null);
+		try {
+			const [ks, s] = await Promise.all([
+				settingsApi.getKillSwitch(),
+				settingsApi.get(),
+			]);
+			setKillSwitch(ks);
+			setSettings(s);
+			setForm(s);
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : '불러오기 실패');
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		load();
+	}, [load]);
+
+	async function handleKillConfirm() {
+		setKillActionLoading(true);
+		try {
+			if (killConfirmAction === 'kill') {
+				await settingsApi.kill();
+			} else {
+				await settingsApi.restore();
+			}
+			setKillConfirmOpen(false);
+			await load();
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : '킬 스위치 처리 실패');
+		} finally {
+			setKillActionLoading(false);
+		}
+	}
+
+	async function handleSettingsSave() {
+		setSettingsLoading(true);
+		try {
+			const updated = await settingsApi.update(form);
+			setSettings(updated);
+			setForm(updated);
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : '설정 저장 실패');
+		} finally {
+			setSettingsLoading(false);
+		}
+	}
+
+	async function handleReset() {
+		setResetLoading(true);
+		try {
+			const defaults = await settingsApi.reset();
+			setSettings(defaults);
+			setForm(defaults);
+			setResetConfirmOpen(false);
+		} catch (e: unknown) {
+			setError(e instanceof Error ? e.message : '초기화 실패');
+		} finally {
+			setResetLoading(false);
+		}
+	}
+
+	if (loading) {
+		return (
+			<Box display="flex" justifyContent="center" py={6}>
+				<CircularProgress />
+			</Box>
+		);
+	}
+
+	return (
+		<Box maxWidth={600}>
+			{error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+
+			{/* Kill Switch */}
+			<Card variant="outlined" sx={{ mb: 3 }}>
+				<CardContent>
+					<Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+						<Typography variant="h6">긴급 킬 스위치</Typography>
+						{killSwitch && (
+							<Chip
+								label={killSwitch.killed ? '중단됨' : '운영 중'}
+								color={killSwitch.killed ? 'error' : 'success'}
+							/>
+						)}
+					</Box>
+					<Typography variant="body2" color="text.secondary" mb={2}>
+						활성화 시 DAG 생성·발화·Activity Simulator 전체 즉시 차단됩니다.
+					</Typography>
+					<Box display="flex" gap={2}>
+						{killSwitch?.killed ? (
+							<Button
+								variant="contained"
+								color="success"
+								onClick={() => { setKillConfirmAction('restore'); setKillConfirmOpen(true); }}
+							>
+								자동화 재개
+							</Button>
+						) : (
+							<Button
+								variant="contained"
+								color="error"
+								onClick={() => { setKillConfirmAction('kill'); setKillConfirmOpen(true); }}
+							>
+								긴급 중단
+							</Button>
+						)}
+					</Box>
+				</CardContent>
+			</Card>
+
+			<Divider sx={{ my: 3 }} />
+
+			{/* Settings Form */}
+			<Typography variant="h6" mb={2}>자동화 설정</Typography>
+
+			<Box display="flex" flexDirection="column" gap={2}>
+				<FormControlLabel
+					control={
+						<Switch
+							checked={form.dagRunEnabled}
+							onChange={(e) => setForm((f) => ({ ...f, dagRunEnabled: e.target.checked }))}
+						/>
+					}
+					label="DAG Run 활성화"
+				/>
+				<FormControlLabel
+					control={
+						<Switch
+							checked={form.publishEnabled}
+							onChange={(e) => setForm((f) => ({ ...f, publishEnabled: e.target.checked }))}
+						/>
+					}
+					label="발화(Publish) 활성화"
+				/>
+				<FormControlLabel
+					control={
+						<Switch
+							checked={form.activitySimulatorEnabled}
+							onChange={(e) => setForm((f) => ({ ...f, activitySimulatorEnabled: e.target.checked }))}
+						/>
+					}
+					label="Activity Simulator 활성화"
+				/>
+				<FormControlLabel
+					control={
+						<Switch
+							checked={form.reviewRequiredBeforePublish}
+							onChange={(e) => setForm((f) => ({ ...f, reviewRequiredBeforePublish: e.target.checked }))}
+						/>
+					}
+					label="발화 전 검수 필요"
+				/>
+				<TextField
+					label="일일 최대 발화 수"
+					type="number"
+					inputProps={{ min: 1, max: 500 }}
+					value={form.maxDailyPublish}
+					onChange={(e) =>
+						setForm((f) => ({
+							...f,
+							maxDailyPublish: Math.max(1, Math.min(500, Number(e.target.value))),
+						}))
+					}
+					sx={{ maxWidth: 200 }}
+				/>
+			</Box>
+
+			<Box display="flex" gap={2} mt={3}>
+				<Button
+					variant="contained"
+					disabled={settingsLoading}
+					onClick={handleSettingsSave}
+				>
+					{settingsLoading ? <CircularProgress size={16} /> : '저장'}
+				</Button>
+				<Button
+					variant="outlined"
+					color="warning"
+					onClick={() => setResetConfirmOpen(true)}
+				>
+					기본값으로 초기화
+				</Button>
+			</Box>
+
+			{/* Kill Confirm Dialog */}
+			<Dialog open={killConfirmOpen} onClose={() => setKillConfirmOpen(false)} maxWidth="xs">
+				<DialogTitle>
+					{killConfirmAction === 'kill' ? '긴급 중단 확인' : '자동화 재개 확인'}
+				</DialogTitle>
+				<DialogContent>
+					{killConfirmAction === 'kill' ? (
+						<Typography color="error">
+							전체 커뮤니티 자동화를 즉시 중단합니다. DAG 생성, 발화, Activity Simulator가 모두 차단됩니다.
+						</Typography>
+					) : (
+						<Typography>커뮤니티 자동화를 재개합니다.</Typography>
+					)}
+				</DialogContent>
+				<DialogActions>
+					<Button onClick={() => setKillConfirmOpen(false)}>취소</Button>
+					<Button
+						variant="contained"
+						color={killConfirmAction === 'kill' ? 'error' : 'success'}
+						disabled={killActionLoading}
+						onClick={handleKillConfirm}
+					>
+						{killActionLoading ? <CircularProgress size={16} /> : '확인'}
+					</Button>
+				</DialogActions>
+			</Dialog>
+
+			{/* Reset Confirm Dialog */}
+			<Dialog open={resetConfirmOpen} onClose={() => setResetConfirmOpen(false)} maxWidth="xs">
+				<DialogTitle>기본값으로 초기화</DialogTitle>
+				<DialogContent>
+					<Typography>설정을 기본값으로 초기화하시겠습니까?</Typography>
+				</DialogContent>
+				<DialogActions>
+					<Button onClick={() => setResetConfirmOpen(false)}>취소</Button>
+					<Button variant="contained" color="warning" disabled={resetLoading} onClick={handleReset}>
+						{resetLoading ? <CircularProgress size={16} /> : '초기화'}
+					</Button>
+				</DialogActions>
+			</Dialog>
+		</Box>
+	);
+}

--- a/app/admin/keywords/keywords-v2.tsx
+++ b/app/admin/keywords/keywords-v2.tsx
@@ -40,6 +40,12 @@ import {
 	type KeywordItem,
 	type KeywordCategory,
 } from '@/app/services/admin/keywords';
+import {
+	ACCEPT_IMAGE_ATTR,
+	MAX_IMAGE_MB,
+	validateImageFile,
+} from '@/app/admin/ai-profiles/_shared/image-upload-constants';
+import { getAdminErrorMessage } from '@/shared/lib/http/admin-fetch';
 import { useConfirm } from '@/shared/ui/admin/confirm-dialog';
 import { useToast } from '@/shared/ui/admin/toast';
 
@@ -74,7 +80,7 @@ function KeywordsContent() {
 	const toast = useToast();
 	const editInputRef = useRef<HTMLInputElement>(null);
 	const [generatingIcon, setGeneratingIcon] = useState<string | undefined>();
-	const [uploadingIcon, setUploadingIcon] = useState<string | undefined>();
+	const [isUploading, setIsUploading] = useState(false);
 	const fileInputRef = useRef<HTMLInputElement>(null);
 
 	// 프롬프트 다이얼로그 상태
@@ -189,8 +195,17 @@ function KeywordsContent() {
 		normalizedKeyword: string,
 		file: File,
 	) => {
+		const validationError = validateImageFile(file);
+		if (validationError) {
+			toast.error(
+				validationError.kind === 'mime'
+					? '지원하지 않는 파일 형식입니다 (JPG, PNG, WebP만 가능)'
+					: `파일이 너무 큽니다 (최대 ${MAX_IMAGE_MB}MB)`,
+			);
+			return;
+		}
 		try {
-			setUploadingIcon(normalizedKeyword);
+			setIsUploading(true);
 			const result = await AdminService.keywords.uploadIcon(normalizedKeyword, file);
 			setItems((prev) =>
 				prev.map((item) =>
@@ -202,9 +217,9 @@ function KeywordsContent() {
 			toast.success('아이콘이 업로드되었습니다.');
 			cancelEdit();
 		} catch (err: any) {
-			toast.error(err.response?.data?.message || '업로드에 실패했습니다.');
+			toast.error(getAdminErrorMessage(err, '업로드에 실패했습니다.'));
 		} finally {
-			setUploadingIcon(undefined);
+			setIsUploading(false);
 		}
 	};
 
@@ -392,7 +407,7 @@ function KeywordsContent() {
 															</IconButton>
 															<input
 																type="file"
-																accept="image/jpeg,image/png,image/webp"
+																accept={ACCEPT_IMAGE_ATTR}
 																style={{ display: 'none' }}
 																ref={fileInputRef}
 																onChange={(e) => {
@@ -406,10 +421,10 @@ function KeywordsContent() {
 																<IconButton
 																	size="small"
 																	onClick={() => fileInputRef.current?.click()}
-																	disabled={uploadingIcon === editMode?.keyword}
+																	disabled={isUploading}
 																	sx={{ p: 0.25 }}
 																>
-																	{uploadingIcon === editMode?.keyword ? (
+																	{isUploading ? (
 																		<CircularProgress size={14} />
 																	) : (
 																		<CloudUploadIcon sx={{ fontSize: 16, color: '#2563eb' }} />

--- a/app/admin/keywords/keywords-v2.tsx
+++ b/app/admin/keywords/keywords-v2.tsx
@@ -31,6 +31,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
 import CircularProgress from '@mui/material/CircularProgress';
 import Tooltip from '@mui/material/Tooltip';
 import AdminService from '@/app/services/admin';
@@ -73,6 +74,8 @@ function KeywordsContent() {
 	const toast = useToast();
 	const editInputRef = useRef<HTMLInputElement>(null);
 	const [generatingIcon, setGeneratingIcon] = useState<string | undefined>();
+	const [uploadingIcon, setUploadingIcon] = useState<string | undefined>();
+	const fileInputRef = useRef<HTMLInputElement>(null);
 
 	// 프롬프트 다이얼로그 상태
 	const [promptDialog, setPromptDialog] = useState<{ open: boolean; item: KeywordItem | null }>({
@@ -179,6 +182,29 @@ function KeywordsContent() {
 			toast.error(err.response?.data?.message || '저장에 실패했습니다.');
 		} finally {
 			setSaving(false);
+		}
+	};
+
+	const handleIconFileUpload = async (
+		normalizedKeyword: string,
+		file: File,
+	) => {
+		try {
+			setUploadingIcon(normalizedKeyword);
+			const result = await AdminService.keywords.uploadIcon(normalizedKeyword, file);
+			setItems((prev) =>
+				prev.map((item) =>
+					item.normalizedKeyword === normalizedKeyword
+						? { ...item, iconUrl: result.iconUrl }
+						: item,
+				),
+			);
+			toast.success('아이콘이 업로드되었습니다.');
+			cancelEdit();
+		} catch (err: any) {
+			toast.error(err.response?.data?.message || '업로드에 실패했습니다.');
+		} finally {
+			setUploadingIcon(undefined);
 		}
 	};
 
@@ -364,6 +390,32 @@ function KeywordsContent() {
 															<IconButton size="small" onClick={cancelEdit}>
 																<CloseIcon sx={{ fontSize: 16 }} />
 															</IconButton>
+															<input
+																type="file"
+																accept="image/jpeg,image/png,image/webp"
+																style={{ display: 'none' }}
+																ref={fileInputRef}
+																onChange={(e) => {
+																	const file = e.target.files?.[0];
+																	if (!file || !editMode) return;
+																	handleIconFileUpload(editMode.keyword, file);
+																	e.currentTarget.value = '';
+																}}
+															/>
+															<Tooltip title="파일에서 업로드" arrow>
+																<IconButton
+																	size="small"
+																	onClick={() => fileInputRef.current?.click()}
+																	disabled={uploadingIcon === editMode?.keyword}
+																	sx={{ p: 0.25 }}
+																>
+																	{uploadingIcon === editMode?.keyword ? (
+																		<CircularProgress size={14} />
+																	) : (
+																		<CloudUploadIcon sx={{ fontSize: 16, color: '#2563eb' }} />
+																	)}
+																</IconButton>
+															</Tooltip>
 														</Box>
 													) : (
 														<Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>

--- a/app/services/admin/community-automation.ts
+++ b/app/services/admin/community-automation.ts
@@ -1,0 +1,315 @@
+import { adminGet, adminPost, adminPut, adminPatch, adminDelete } from '@/shared/lib/http/admin-fetch';
+
+const BASE = '/admin/v2/community-automation';
+
+// ==================== Types ====================
+
+export type CampaignStatus = 'draft' | 'active' | 'paused' | 'archived';
+export type DagTemplateId = 'post' | 'auto_comment' | 'target_comment' | 'reply';
+
+export interface Campaign {
+	id: string;
+	name: string;
+	category: string;
+	status: CampaignStatus;
+	startAt: string | null;
+	endAt: string | null;
+	dagTemplateId: string | null;
+	timingParams: Record<string, unknown> | null;
+	createdAt: string;
+	updatedAt: string | null;
+	createdBy: string | null;
+}
+
+export interface CreateCampaignBody {
+	name: string;
+	category: string;
+	dagTemplateId?: DagTemplateId;
+	startAt?: string;
+	endAt?: string;
+}
+
+export interface ListCampaignsQuery {
+	status?: CampaignStatus;
+	from?: string;
+	to?: string;
+}
+
+export interface TriggerDagRunBody {
+	dagTemplateId?: DagTemplateId;
+	count?: number;
+}
+
+export type ContentStatus =
+	| 'draft'
+	| 'pending_review'
+	| 'approved'
+	| 'scheduled'
+	| 'published'
+	| 'rejected'
+	| 'quality_failed'
+	| 'withdrawn';
+
+export interface QualityScores {
+	pii?: number;
+	profanity?: number;
+	[key: string]: number | undefined;
+}
+
+export interface Content {
+	id: string;
+	campaignId: string | null;
+	dagRunId: string | null;
+	ghostAccountId: string | null;
+	articleId: string | null;
+	commentId: string | null;
+	targetType: 'POST' | 'COMMENT' | 'REPLY' | null;
+	targetParentId: string | null;
+	status: ContentStatus;
+	generatedText: string | null;
+	finalText: string | null;
+	qualityScores: QualityScores | null;
+	noiseSeed: number | null;
+	scheduledAt: string | null;
+	publishedAt: string | null;
+	reviewActorId: string | null;
+	reviewedAt: string | null;
+	rejectionReason: string | null;
+	createdAt: string;
+	updatedAt: string | null;
+}
+
+export interface BulkApplyBody {
+	contentIds: string[];
+	action: 'approve' | 'reject' | 'withdraw';
+	reason?: string;
+}
+
+export interface BulkApplyResult {
+	succeeded: string[];
+	failed: Array<{ id: string; error: string }>;
+}
+
+export interface ContentStatusCount {
+	status: ContentStatus;
+	count: number;
+}
+
+export interface DailyStat {
+	date: string;
+	published: number;
+	rejected: number;
+	withdrawn: number;
+}
+
+export interface MetricsSummary {
+	period: { from: string; to: string };
+	schema: string;
+	contentByStatus: ContentStatusCount[];
+	totalPublished: number;
+	totalRejected: number;
+	totalWithdrawn: number;
+	totalPendingReview: number;
+	auditActionCounts: Record<string, number>;
+	dailyStats: DailyStat[];
+}
+
+export interface QueueDepth {
+	pending_review: number;
+	scheduled: number;
+	draft: number;
+	quality_failed: number;
+}
+
+export type ReactionSpeed = 'high' | 'mid' | 'low';
+export type ActivityCurve = 'morning' | 'night' | 'random';
+
+export interface CommunityTraits {
+	reactionSpeed?: ReactionSpeed;
+	noiseStrength?: number;
+	activityCurve?: ActivityCurve;
+}
+
+export interface GhostPersonaInfo {
+	id: string;
+	ghostUserId: string;
+	status: string;
+	archetypeCode: string;
+	archetypeName: string;
+	communityTraits: CommunityTraits;
+}
+
+export interface ArchetypeDistribution {
+	archetypeCode: string;
+	count: number;
+	percentage: number;
+}
+
+export interface PersonaDiversityReport {
+	totalActiveGhosts: number;
+	archetypeDistribution: ArchetypeDistribution[];
+	activityCurveDistribution: Record<string, number>;
+	diversityScore: number;
+}
+
+export interface CommunitySettings {
+	dagRunEnabled: boolean;
+	publishEnabled: boolean;
+	activitySimulatorEnabled: boolean;
+	maxDailyPublish: number;
+	reviewRequiredBeforePublish: boolean;
+}
+
+export interface KillSwitchStatus {
+	killed: boolean;
+}
+
+// ==================== Campaigns ====================
+
+export const campaigns = {
+	list: async (query?: ListCampaignsQuery): Promise<Campaign[]> => {
+		const params: Record<string, string> = {};
+		if (query?.status) params.status = query.status;
+		if (query?.from) params.from = query.from;
+		if (query?.to) params.to = query.to;
+		const result = await adminGet<{ data: Campaign[] }>(`${BASE}/campaigns`, params);
+		return result.data;
+	},
+
+	create: async (body: CreateCampaignBody): Promise<Campaign> => {
+		const result = await adminPost<{ data: Campaign }>(`${BASE}/campaigns`, body);
+		return result.data;
+	},
+
+	get: async (id: string): Promise<Campaign> => {
+		const result = await adminGet<{ data: Campaign }>(`${BASE}/campaigns/${id}`);
+		return result.data;
+	},
+
+	activate: async (id: string): Promise<void> => {
+		await adminPatch(`${BASE}/campaigns/${id}/activate`);
+	},
+
+	pause: async (id: string): Promise<void> => {
+		await adminPatch(`${BASE}/campaigns/${id}/pause`);
+	},
+
+	archive: async (id: string): Promise<void> => {
+		await adminPatch(`${BASE}/campaigns/${id}/archive`);
+	},
+
+	triggerDagRun: async (id: string, body?: TriggerDagRunBody): Promise<{ jobsEnqueued: number }> => {
+		const result = await adminPost<{ data: { jobsEnqueued: number } }>(`${BASE}/campaigns/${id}/dag-run`, body ?? {});
+		return result.data;
+	},
+};
+
+// ==================== Review Queue ====================
+
+export const reviewQueue = {
+	list: async (): Promise<Content[]> => {
+		const result = await adminGet<{ data: Content[] }>(`${BASE}/review-queue`);
+		return result.data;
+	},
+
+	approve: async (id: string): Promise<void> => {
+		await adminPatch(`${BASE}/review-queue/${id}/approve`);
+	},
+
+	reject: async (id: string, reason: string): Promise<void> => {
+		await adminPatch(`${BASE}/review-queue/${id}/reject`, { reason });
+	},
+
+	inject: async (id: string, newText: string): Promise<void> => {
+		await adminPatch(`${BASE}/review-queue/${id}/inject`, { newText });
+	},
+
+	regenerate: async (id: string, body?: { campaignId?: string; dagTemplateId?: string }): Promise<void> => {
+		await adminPost(`${BASE}/review-queue/${id}/regenerate`, body ?? {});
+	},
+
+	withdraw: async (id: string, reason: string): Promise<void> => {
+		await adminPatch(`${BASE}/review-queue/${id}/withdraw`, { reason });
+	},
+
+	bulk: async (body: BulkApplyBody): Promise<BulkApplyResult> => {
+		const result = await adminPost<{ data: BulkApplyResult }>(`${BASE}/review-queue/bulk`, body);
+		return result.data;
+	},
+};
+
+// ==================== Metrics ====================
+
+export const metrics = {
+	summary: async (from?: string, to?: string): Promise<MetricsSummary> => {
+		const params: Record<string, string> = {};
+		if (from) params.from = from;
+		if (to) params.to = to;
+		const result = await adminGet<{ data: MetricsSummary }>(`${BASE}/metrics/summary`, params);
+		return result.data;
+	},
+
+	queueDepth: async (): Promise<QueueDepth> => {
+		const result = await adminGet<{ data: QueueDepth }>(`${BASE}/metrics/queue-depth`);
+		return result.data;
+	},
+};
+
+// ==================== Personas ====================
+
+export const personas = {
+	list: async (): Promise<GhostPersonaInfo[]> => {
+		const result = await adminGet<{ data: GhostPersonaInfo[] }>(`${BASE}/personas`);
+		return result.data;
+	},
+
+	diversity: async (): Promise<PersonaDiversityReport> => {
+		const result = await adminGet<{ data: PersonaDiversityReport }>(`${BASE}/personas/diversity`);
+		return result.data;
+	},
+
+	get: async (id: string): Promise<GhostPersonaInfo> => {
+		const result = await adminGet<{ data: GhostPersonaInfo }>(`${BASE}/personas/${id}`);
+		return result.data;
+	},
+
+	setTraits: async (id: string, traits: CommunityTraits): Promise<void> => {
+		await adminPut(`${BASE}/personas/${id}/community-traits`, traits);
+	},
+
+	deleteTraits: async (id: string): Promise<void> => {
+		await adminDelete(`${BASE}/personas/${id}/community-traits`);
+	},
+};
+
+// ==================== Settings ====================
+
+export const communitySettings = {
+	getKillSwitch: async (): Promise<KillSwitchStatus> => {
+		const result = await adminGet<{ data: KillSwitchStatus }>(`${BASE}/settings/kill-switch`);
+		return result.data;
+	},
+
+	kill: async (): Promise<void> => {
+		await adminPost(`${BASE}/settings/kill-switch/kill`);
+	},
+
+	restore: async (): Promise<void> => {
+		await adminPost(`${BASE}/settings/kill-switch/restore`);
+	},
+
+	get: async (): Promise<CommunitySettings> => {
+		const result = await adminGet<{ data: CommunitySettings }>(`${BASE}/settings`);
+		return result.data;
+	},
+
+	update: async (body: Partial<CommunitySettings>): Promise<CommunitySettings> => {
+		const result = await adminPatch<{ data: CommunitySettings }>(`${BASE}/settings`, body);
+		return result.data;
+	},
+
+	reset: async (): Promise<CommunitySettings> => {
+		const result = await adminDelete<{ data: CommunitySettings }>(`${BASE}/settings`);
+		return result.data;
+	},
+};

--- a/app/services/admin/index.ts
+++ b/app/services/admin/index.ts
@@ -24,6 +24,29 @@ export type { NoticeListParams } from './notices';
 export { seo } from './seo';
 export type { PageMeta, SitemapKind } from './seo';
 export { cardNewsGeneration } from './card-news-generation';
+export { campaigns, reviewQueue, metrics, personas, communitySettings } from './community-automation';
+export type {
+	Campaign,
+	CampaignStatus,
+	DagTemplateId,
+	CreateCampaignBody,
+	ListCampaignsQuery,
+	TriggerDagRunBody,
+	Content,
+	ContentStatus,
+	BulkApplyBody,
+	BulkApplyResult,
+	MetricsSummary,
+	QueueDepth,
+	DailyStat,
+	GhostPersonaInfo,
+	PersonaDiversityReport,
+	CommunityTraits,
+	CommunitySettings,
+	KillSwitchStatus,
+	ReactionSpeed,
+	ActivityCurve,
+} from './community-automation';
 export type { CardNewsTopic, QueueStats, JobStatus } from './card-news-generation';
 export { reports, userReview, profileImages } from './moderation';
 export {
@@ -168,6 +191,7 @@ import { aiProfileGenerator } from './ai-profile-generator';
 import { promotions } from './promotions';
 import { gemProducts } from './gem-products';
 import { iapCatalog } from './iap-catalog';
+import { campaigns, reviewQueue, metrics, personas, communitySettings } from './community-automation';
 
 const AdminService = {
 	stats,
@@ -218,6 +242,11 @@ const AdminService = {
 	iapCatalog,
 	seo,
 	cardNewsGeneration,
+	campaigns,
+	reviewQueue,
+	metrics,
+	personas,
+	communitySettings,
 };
 
 export default AdminService;

--- a/app/services/admin/keywords.ts
+++ b/app/services/admin/keywords.ts
@@ -1,4 +1,4 @@
-import { adminGet, adminPost, adminPatch, adminDelete } from '@/shared/lib/http/admin-fetch';
+import { adminGet, adminPost, adminPatch, adminDelete, adminUpload } from '@/shared/lib/http/admin-fetch';
 
 export const KEYWORD_CATEGORIES = {
 	HOBBY: '취미',
@@ -69,6 +69,17 @@ export const keywords = {
 		const encoded = encodeURIComponent(keyword);
 		const res = await adminDelete<{ data: { deletedCount: number } }>(
 			`/admin/v2/keywords/${encoded}`,
+		);
+		return res.data;
+	},
+
+	uploadIcon: async (normalizedKeyword: string, file: File): Promise<{ iconUrl: string }> => {
+		const fd = new FormData();
+		fd.append('file', file);
+		fd.append('normalizedKeyword', normalizedKeyword);
+		const res = await adminUpload<{ data: { iconUrl: string } }>(
+			'/admin/v2/keywords/icon/upload',
+			fd,
 		);
 		return res.data;
 	},

--- a/shared/ui/admin/sidebar.tsx
+++ b/shared/ui/admin/sidebar.tsx
@@ -55,6 +55,7 @@ export const NAV_CATEGORIES: NavCategory[] = [
       { href: '/admin/blacklist', label: '블랙리스트' },
       { href: '/admin/review-inbox', label: '검토 인박스' },
       { href: '/admin/community', label: '커뮤니티' },
+      { href: '/admin/community-automation', label: '커뮤니티 자동화' },
       { href: '/admin/support-chat', label: '고객 지원' },
       { href: '/admin/universities', label: '대학교 관리' },
       { href: '/admin/universities/clusters', label: '대학교 클러스터' },


### PR DESCRIPTION
## Summary

**커뮤니티 자동화 어드민 대시보드** 전체 구현. `/admin/community-automation` 경로 하위 5개 섹션.

**Service Layer**
- `app/services/admin/community-automation.ts` — 신규 도메인 모듈, 5개 객체 30개 API 함수
- `app/services/admin/index.ts` — re-export + AdminService 객체 추가

**Pages** (`app/admin/community-automation/`)
- `layout.tsx` — 탭 네비게이션 (캠페인/검수큐/메트릭스/페르소나/설정)
- `page.tsx` — `/campaigns`로 리다이렉트

**Campaigns** — CRUD 테이블, 상태전이 버튼 (activate/pause/archive), 수동 DAG Run 다이얼로그 (template + count 1-10)

**Review Queue** — 체크박스 선택, 일괄 승인/거절/회수, 승인/거절/수정승인/재생성/회수 per-row 액션, reject/withdraw 사유 입력

**Metrics** — 전체 현황 카드 (published/pending/rejected/withdrawn), 큐 깊이 카드, 상태별 테이블, 일별 통계 테이블, 날짜 범위 필터

**Personas** — 다양성 리포트 (diversityScore + archetype 분포), Ghost 목록, 커뮤니티 트레이트 편집(reactionSpeed/noiseStrength slider/activityCurve) + 삭제

**Settings** — 킬 스위치 카드(kill/restore + confirm), 설정 폼(5개 필드), 기본값 초기화

**Navigation** — `shared/ui/admin/sidebar.tsx` 에 커뮤니티 자동화 추가

## Pre-Landing Review

TypeScript: 오류 없음 (pnpm tsc --noEmit pass).  
테스트 실패: 모두 pre-existing (card-news, LongformForm, e2e, community.test.js — 이번 변경과 무관).

## Test plan
- [ ] `/admin/community-automation/campaigns` 접속 후 캠페인 목록 조회
- [ ] 캠페인 생성 다이얼로그 → 생성 확인
- [ ] DAG Run 다이얼로그 → 실행 확인
- [ ] `/admin/community-automation/review-queue` — 검수 대기 목록
- [ ] 승인/거절/수정승인/재생성/회수 동작
- [ ] 일괄 액션 (체크박스 선택 후 Bulk)
- [ ] `/admin/community-automation/metrics` — 통계 카드/테이블
- [ ] `/admin/community-automation/personas` — 다양성 리포트 + 트레이트 편집
- [ ] `/admin/community-automation/settings` — 킬 스위치 + 설정 저장
- [ ] 사이드바 커뮤니티 자동화 링크 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)